### PR TITLE
Fix running `create-rwjblue-release-it-setup`

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,6 +79,8 @@ module.exports = {
   async setupReleaseIt(rootPath) {
     await execa('create-rwjblue-release-it-setup', ['--no-install'], {
       cwd: rootPath,
+      preferLocal: true,
+      localDir: __dirname,
     });
   },
 


### PR DESCRIPTION
The previous implementation failed when `create-rwjblue-release-it-setup` was not installed globally, or when the current working directory was not the one of the blueprint (e.g. running from `npx`). While `execa` supports running locally installed binaries by their name, by default it looks for them based on whatever `process.cwd()` is. So we need to tell `execa` to look for the binary based on the blueprint's directory, not the current one.

Fixes #11

Prior to merging, this can be tested running

```bash
npx ember-cli addon my-shiny-new-addon -b embroider-build/addon-blueprint#fix-execa-releaseit
```

cc @dfreeman @sergeastapov 