### PR TITLE
Replace `babel-eslint` with `@babel/eslint-parser`

### DIFF
--- a/files/packages/__name__/.eslintrc.js
+++ b/files/packages/__name__/.eslintrc.js
@@ -2,7 +2,7 @@
 
 module.exports = {
   root: true,
-  parser: 'babel-eslint',
+  parser: '@babel/eslint-parser',
   parserOptions: {
     ecmaVersion: 'latest',
     sourceType: 'module',

--- a/files/packages/__name__/package.json
+++ b/files/packages/__name__/package.json
@@ -29,12 +29,12 @@
   },
   "devDependencies": {
     "@babel/core": "^7.17.0",
+    "@babel/eslint-parser": "^7.18.2",
     "@babel/plugin-proposal-class-properties": "^7.16.7",
     "@babel/plugin-proposal-decorators": "^7.17.0",
     "@babel/plugin-syntax-decorators": "^7.17.0",
     "@embroider/addon-dev": "^1.0.0",
     "@rollup/plugin-babel": "^5.3.0",
-    "babel-eslint": "^10.1.0",
     "ember-template-lint": "^4.0.0",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.3.0",


### PR DESCRIPTION
Using `ecmaVersion: 'latest'` (introduced in #6) seems to not work at all, due to `babel-eslint` being outdated und unmaintained. This replaces it with is successor `@babel/eslint-parser`.

There has been some discussion about doing the same in the main blueprint (see https://github.com/ember-cli/ember-cli/issues/9307 and https://github.com/emberjs/rfcs/issues/817), but in our case I think the switch should be straightforward, for example as we already have a `babel.config.js`.

/cc @SergeAstapov @NullVoxPopuli