### PR TITLE
chore!: drop Node.js 12 support

### DIFF
--- a/files/.github/workflows/ci.yml
+++ b/files/.github/workflows/ci.yml
@@ -17,11 +17,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: <%= yarn ? 'yarn' : 'npm' %>
       - name: Install Dependencies
         run: <%= yarn ? 'yarn install --frozen-lockfile' : 'npm ci' %>
@@ -35,10 +35,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: <%= yarn ? 'yarn' : 'npm' %>
       - name: Install Dependencies
         run: <%= yarn ? 'yarn install --no-lockfile' : 'npm install --no-shrinkwrap' %>
@@ -64,11 +64,11 @@ jobs:
           - embroider-optimized
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: <%= yarn ? 'yarn' : 'npm' %>
       - name: Install Dependencies
         run: <%= yarn ? 'yarn install --frozen-lockfile' : 'npm ci' %>

--- a/files/README.md
+++ b/files/README.md
@@ -9,6 +9,7 @@ Compatibility
 
 * Ember.js v3.24 or above
 * Embroider or ember-auto-import v2
+* Node.js v14 or above
 
 
 Installation

--- a/files/packages/__name__/package.json
+++ b/files/packages/__name__/package.json
@@ -45,7 +45,7 @@
     "rollup": "^2.67.0"
   },
   "engines": {
-    "node": "12.* || >= 14"
+    "node": "14.* || 16.* || >= 18"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"

--- a/package.json
+++ b/package.json
@@ -19,11 +19,11 @@
     "sort-package-json": "^1.54.0"
   },
   "engines": {
-    "node": "12.* || >= 14.*"
+    "node": "14.* || 16.* || >= 18"
   },
   "volta": {
-    "node": "12.22.10",
-    "yarn": "1.22.17"
+    "node": "14.19.3",
+    "yarn": "1.22.18"
   },
   "devDependencies": {
     "prettier": "^2.5.1"


### PR DESCRIPTION
Node.js 12 is End of Life as of April 30, 2022