### PR TITLE
Use Github reference in Usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Usage
 ------------------------------------------------------------------------------
 
 ```bash
-ember addon my-addon -b @embroider/addon-blueprint --yarn
+ember addon my-addon -b embroider-build/addon-blueprint --yarn
 ```
 
 


### PR DESCRIPTION
While the blueprint is still not released, the current instructions are misleading...

Fixes #19 