### PR TITLE
Refactor extending test-app's package.json, add `ember-disable-prototype-extensions`

### DIFF
--- a/additional-test-app-package.json
+++ b/additional-test-app-package.json
@@ -1,0 +1,13 @@
+{
+  "devDependencies": {
+    "@embroider/test-setup": "^1.7.1",
+    "ember-disable-prototype-extensions": "^1.1.3",
+    "ember-try": "^2.0.0",
+    "ember-source-channel-url": "^3.0.0"
+  },
+  "scripts": {
+    "test:watch": "ember test --server",
+    "test": "npm-run-all lint \"test:!(watch)\""
+  },
+  "private": true
+}

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const SilentError = require('silent-error');
 const sortPackageJson = require('sort-package-json');
 const normalizeEntityName = require('ember-cli-normalize-entity-name');
 const execa = require('execa');
+const { merge } = require('lodash');
 
 let date = new Date();
 
@@ -50,16 +51,12 @@ module.exports = {
 
   async updateTestAppPackageJson(packageJsonPath) {
     const pkg = require(packageJsonPath);
+    const additions = require('./additional-test-app-package.json');
 
+    merge(pkg, additions);
+
+    // we must explicitly add our own v2 addon here, the implicit magic of the legacy dummy app does not work
     pkg.devDependencies[this.locals(this.options).addonName] = '^0.0.0';
-    pkg.devDependencies['@embroider/test-setup'] = '^1.0.0';
-    pkg.devDependencies['ember-source-channel-url'] = '^3.0.0';
-    pkg.devDependencies['ember-try'] = '^2.0.0';
-
-    pkg.scripts['test:watch'] = 'ember test --server';
-    pkg.scripts['test'] = 'npm-run-all lint \\"test:!(watch)\\"';
-
-    pkg.private = true;
 
     return fs.writeFile(
       packageJsonPath,

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "ember-cli-string-utils": "^1.1.0",
     "execa": "^5.1.1",
     "fs-extra": "^10.0.0",
+    "lodash": "^4.17.21",
     "silent-error": "^1.1.1",
     "sort-package-json": "^1.54.0"
   },


### PR DESCRIPTION
This makes it easier to tweak the test-app's package.json, using a separate json file that is merged into it. Similar to what Ember-CLI does for [additional devDependencies of addons](https://github.com/ember-cli/ember-cli/blob/ee6d372df2e16384a92f06800329eeb23c83a7d1/blueprints/addon/additional-dev-dependencies.json). We already added most additional dependencies, except for `ember-disable-prototype-extensions`, which is added here. Closes #16.

cc @bertdeblock