### PR TITLE
Provide a fixed root to @babel/eslint-parser

### DIFF
--- a/files/__addonLocation__/.eslintrc.js
+++ b/files/__addonLocation__/.eslintrc.js
@@ -9,6 +9,9 @@ module.exports = {
     ecmaFeatures: {
       legacyDecorators: true,
     },
+    babelOptions: {
+      root: __dirname,
+    },
   },
   plugins: ['ember'],
   extends: [


### PR DESCRIPTION
`@babel/eslint-parser` is strict about only locating your babel config in the current working directory by default. But VSCode (for example) runs eslint from the monorepo root, resulting in a broken configuration.

This sets the root explicitly so that regardless of where you invoke eslint form it can still find the babel.config.json.