### PR TITLE
Rebuild on addon changes

### DIFF
--- a/files/test-app-overrides/ember-cli-build.js
+++ b/files/test-app-overrides/ember-cli-build.js
@@ -4,23 +4,11 @@ const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
 module.exports = function (defaults) {
   let app = new EmberApp(defaults, {
-    // Add options here
+    autoImport: {
+      watchDependencies: ['<%= addonName %>']
+    }
   });
 
-  // Use `app.import` to add additional libraries to the generated
-  // output files.
-  //
-  // If you need to use different assets in different
-  // environments, specify an object as the first parameter. That
-  // object's keys should be the environment name and the values
-  // should be the asset to use in that environment.
-  //
-  // If the library that you are including contains AMD or ES6
-  // modules that you would like to import into your application
-  // please specify an object with the list of modules as keys
-  // along with the exports of each module as its value.
-
   const { maybeEmbroider } = require('@embroider/test-setup');
-
   return maybeEmbroider(app);
 };


### PR DESCRIPTION
The test-app uses the classic build pipeline by default, which means the addon is consumed through ember-auto-import, which means if we want to get livereload for code in the addon we need ember-auto-import's `watchDependencies` option.