### PR TITLE
Reload the test app when changes to the addon are detected

### DIFF
--- a/files/test-app-overrides/ember-cli-build.js
+++ b/files/test-app-overrides/ember-cli-build.js
@@ -2,9 +2,14 @@
 
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
+const packageJson = require('./package');
+
 module.exports = function (defaults) {
   let app = new EmberApp(defaults, {
     // Add options here
+    autoImport: {
+      watchDependencies: Object.keys(packageJson.dependencies),
+    },
   });
 
   // Use `app.import` to add additional libraries to the generated

--- a/index.js
+++ b/index.js
@@ -64,7 +64,8 @@ module.exports = {
     merge(pkg, additions);
 
     // we must explicitly add our own v2 addon here, the implicit magic of the legacy dummy app does not work
-    pkg.devDependencies[this.locals(this.options).addonName] = '^0.0.0';
+    pkg.dependencies = pkg.dependencies || {};
+    pkg.dependencies[this.locals(this.options).addonName] = '^0.0.0';
 
     return fs.writeFile(
       packageJsonPath,


### PR DESCRIPTION
Something folks from v1 addons are used to: the test app reloading / re-building when changes to the addon are detected.

How to test:
 - invoke the blueprint
 - have two terminals:
   - start the app
   - start the addon in watch mode
- make changes to the addon
- notice those changes are reflected in the app 


Related: https://github.com/embroider-build/embroider/issues/1184
