### PR TITLE
Add support for npm and pnpm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,18 +12,9 @@ env:
   CI: true
 
 jobs:
-  install_deps:
-    name: Install Dependencies
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./.github/actions/pnpm
-
-
   lint_js:
     name: Lint JS
     runs-on: ubuntu-latest
-    needs: ['install_deps']
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/pnpm
@@ -32,7 +23,6 @@ jobs:
 
   test_type_checking:
     name: "Tests: Type Check"
-    needs: ['install_deps']
     timeout-minutes: 5
     runs-on: ubuntu-latest
 
@@ -46,7 +36,6 @@ jobs:
     name: Tests
     timeout-minutes: 5
     runs-on: ubuntu-latest
-    needs: ['install_deps']
     strategy:
       matrix:
         # how to say "not these" so we don't miss anything?

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,18 @@ env:
   CI: true
 
 jobs:
+  install_deps:
+    name: Install Dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/pnpm
+
+
   lint_js:
     name: Lint JS
     runs-on: ubuntu-latest
+    needs: ['install_deps']
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/pnpm
@@ -23,6 +32,7 @@ jobs:
 
   test_type_checking:
     name: "Tests: Type Check"
+    needs: ['install_deps']
     timeout-minutes: 5
     runs-on: ubuntu-latest
 
@@ -36,19 +46,22 @@ jobs:
     name: Tests
     timeout-minutes: 5
     runs-on: ubuntu-latest
+    needs: ['install_deps']
     strategy:
       matrix:
         # how to say "not these" so we don't miss anything?
         # waiting on a an api from vitest for querying
         # the list of tests ahead of time before running them.
         slow-test:
-          - defaults
+          - defaults with npm
+          - defaults with yarn
+          - defaults with pnpm
           - addon-location
           - test-app-location
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/pnpm
       - run: pnpm add --global ember-cli yarn
-      - run: pnpm vitest --testNamePattern ${{ matrix.slow-test }}
+      - run: pnpm vitest --testNamePattern "${{ matrix.slow-test }}"
         working-directory: tests
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         slow-test:
           - defaults with npm
           - defaults with yarn
-          # - defaults with pnpm
+          - defaults with pnpm
           - addon-location
           - test-app-location
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         slow-test:
           - defaults with npm
           - defaults with yarn
-          - defaults with pnpm
+          # - defaults with pnpm
           - addon-location
           - test-app-location
     steps:

--- a/files/__addonLocation__/package.json
+++ b/files/__addonLocation__/package.json
@@ -42,6 +42,7 @@
     "eslint-plugin-ember": "^10.5.8",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^4.0.0",
+    "prettier": "^2.5.1",
     "rollup": "^2.67.0",
     "rollup-plugin-copy": "^3.4.0"
   },

--- a/files/package.json
+++ b/files/package.json
@@ -5,19 +5,7 @@
   "repository": "",
   "license": "MIT",
   "author": "",
-  "scripts": {
-    "prepare": "yarn build",
-    "build": "yarn workspace <%= addonName %> run build",
-
-    "start": "concurrently 'npm:start:*' --restart-after 5000 --prefix-colors cyan,white,yellow",
-    "start:addon": "yarn workspace <%= addonName %> run start",
-    "start:test": "yarn workspace <%= testAppInfo.name.dashed %> run start",
-
-    "lint": "yarn workspaces run lint",
-    "lint:fix": "yarn workspaces run lint:fix",
-
-    "test": "yarn workspaces run test"
-  },
+  "scripts": {},
   "devDependencies": {
     "concurrently": "^7.2.1",
     "prettier": "^2.5.1"

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ let date = new Date();
 
 const { addonInfoFromOptions, testAppInfoFromOptions, withoutAddonOptions } = require('./src/info');
 const { scripts } = require('./src/root-package-json');
+const pnpm = require('./src/pnpm');
 
 const description = 'The default blueprint for Embroider v2 addons.';
 
@@ -64,10 +65,7 @@ module.exports = {
     );
 
     if (options.pnpm) {
-      let content =
-        `packages:\n` + `  - '${addonInfo.location}'\n` + `  - '${testAppInfo.location}'\n`;
-
-      await fs.writeFile(path.join(options.target, 'pnpm-workspace.yaml'), content);
+      tasks.push(pnpm.createWorkspacesFile(options.target, addonInfo, testAppInfo));
     }
 
     if (options.releaseIt) {

--- a/index.js
+++ b/index.js
@@ -41,7 +41,6 @@ module.exports = {
       welcome: false,
     };
 
-
     await appBlueprint.install(appOptions);
 
     let tasks = [

--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ module.exports = {
   },
 
   async overrideTestAppFiles(testAppPath, overridesPath) {
-    // we cannot us fs.move, as it will replace the directory, removing the other files of the app blueprin
+    // we cannot us fs.move, as it will replace the directory, removing the other files of the app blueprint
     // but fs.copy works as we need it. Just have to remove the overrides directory afterwards.
     await fs.copy(overridesPath, testAppPath, {
       overwrite: true,

--- a/src/pnpm.js
+++ b/src/pnpm.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const fs = require('fs/promises');
+const path = require('path');
+
+/**
+ * @typedef {import('./types').AddonInfo} AddonInfo
+ * @typedef {import('./types').TestAppInfo} TestAppInfo
+ */
+
+/**
+ * @param {string} targetPath
+ * @param {AddonInfo} addonInfo
+ * @param {TestAppInfo} testAppInfo
+ */
+async function createWorkspacesFile(targetPath, addonInfo, testAppInfo) {
+  let content = `packages:\n` + `  - '${addonInfo.location}'\n` + `  - '${testAppInfo.location}'\n`;
+
+  await fs.writeFile(path.join(targetPath, 'pnpm-workspace.yaml'), content);
+}
+
+module.exports = {
+  createWorkspacesFile,
+};

--- a/src/root-package-json.js
+++ b/src/root-package-json.js
@@ -1,0 +1,129 @@
+// @ts-check
+const assert = require('assert');
+
+/**
+ * @typedef {import('./types').Options} Options
+ *
+ * @typedef {object} Info
+ * @property {import('./types').AddonInfo} addon
+ * @property {import('./types').TestAppInfo} testApp
+ *
+ */
+const { addonInfoFromOptions, testAppInfoFromOptions } = require('./info');
+
+module.exports = {
+  /**
+   * @param {Options} options
+   */
+  scripts(options) {
+    let { packageManager, yarn, pnpm } = options;
+
+    let info = {
+      addon: addonInfoFromOptions(options),
+      testApp: testAppInfoFromOptions(options),
+    };
+
+    if (packageManager === 'pnpm' || pnpm) {
+      let result = scripts.pnpm(options, info);
+
+      delete result.workspaces;
+
+      return result;
+    }
+
+    if (packageManager === 'yarn' || yarn) {
+      return scripts.yarn(options, info);
+    }
+
+    return scripts.npm(options, info);
+  },
+};
+
+let scripts = {
+  /**
+   * @param {Options} options
+   * @param {Info} info
+   */
+  npm: (options, info) => {
+    let { packageName: addonName } = info.addon;
+    let { packageName: testAppName } = info.addon;
+
+    return {
+      prepare: 'npm run build',
+      build: `npm run build --workspace ${addonName}`,
+
+      start: "concurrently 'npm:start:*' --restart-after 5000 --prefix-colors cyan,white,yellow",
+      'start:tests': `npm start --workspace ${testAppName}`,
+      'start:addon': `npm start --workspace ${addonName} -- --no-watch.clearScreen`,
+
+      test: `npm test --workspace ${testAppName}`,
+
+      lint: 'npm run lint --workspaces --if-present',
+      'lint:fix': 'npm run lint:fix --workspaces --if-present',
+    };
+  },
+
+  /**
+   * @param {Options} options
+   * @param {Info} info
+   */
+  yarn: (options, info) => {
+    let { packageName: addonName } = info.addon;
+    let { packageName: testAppName } = info.addon;
+
+    return {
+      prepare: `yarn build`,
+      build: `yarn workspace ${addonName} run build`,
+
+      start: `concurrently 'npm:start:*' --restart-after 5000 --prefix-colors cyan,white,yellow`,
+      'start:addon': `yarn workspace ${addonName} run start`,
+      'start:test': `yarn workspace ${testAppName} run start`,
+
+      test: 'yarn workspaces run test',
+
+      lint: 'yarn workspaces run lint',
+      'lint:fix': 'yarn workspaces run lint:fix',
+    };
+  },
+
+  /**
+   * @param {Options} options
+   * @param {Info} info
+   */
+  pnpm: (options, info) => {
+    let { packageName: addonName } = info.addon;
+    let { packageName: testAppName } = info.addon;
+
+    return {
+      /**
+       * For most optimized C.I., this will likely want to be removed, but
+       * the prepare scripts helps folks get going quicker without having to understand
+       * that every step in C.I. that needs the addon also needs the addon to be built first.
+       */
+      prepare: `pnpm build`,
+      build: `pnpm --filter ${addonName} build`,
+      /**
+       * restart-after exists because ember-cli continually crashes
+       * when addon code changes from underneath it.
+       *
+       * See also: https://github.com/ember-cli/ember-cli/issues/9584
+       *
+       * Colors are customizable
+       */
+      start: "concurrently 'npm:start:*' --restart-after 5000 --prefix-colors cyan,white,yellow",
+      'start:tests': `pnpm --filter ${testAppName} start`,
+      'start:addon': `pnpm --filter ${addonName} start --no-watch.clearScreen`,
+
+      /**
+       * Note that this test is different from v1 addon's test, which runs all of ember-try as well.
+       * ember-try requires some alternate lockfile behaviors that we can't easily abstract into a
+       * package.json script -- but will be present in C.I.
+       *  (this is a consequence of enforced strict peers)
+       */
+      test: `pnpm --filter ${testAppName} test`,
+
+      lint: "pnpm --filter '*' lint",
+      'lint:fix': "pnpm --filter '*' lint:fix",
+    };
+  },
+};

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,4 +1,5 @@
 import { type Options, execa } from 'execa';
+import fse from 'fs-extra';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -30,52 +31,92 @@ describe('ember addon <the addon> -b <this blueprint>', () => {
     return { result, name };
   }
 
-  describe('defaults', () => {
-    let cwd = '';
-    let tmpDir = '';
-    let distDir = '';
+  ['npm', 'yarn' /*, 'pnpm' */].map((packageManager) => {
+    describe(`defaults with ${packageManager}`, () => {
+      let cwd = '';
+      let tmpDir = '';
+      let distDir = '';
 
-    beforeAll(async () => {
-      tmpDir = await createTmp();
+      beforeAll(async () => {
+        tmpDir = await createTmp();
 
-      let { name } = await createAddon({ options: { cwd: tmpDir } });
+        console.debug(`Debug test repo at ${tmpDir}`);
 
-      cwd = path.join(tmpDir, name);
-      distDir = path.join(cwd, name, 'dist');
+        let { name } = await createAddon({
+          args: [`--${packageManager}=true`],
+          options: { cwd: tmpDir },
+        });
 
-      await install({ cwd });
-    });
+        cwd = path.join(tmpDir, name);
+        distDir = path.join(cwd, name, 'dist');
 
-    afterAll(async () => {
-      fs.rm(tmpDir, { recursive: true });
-    });
+        await install({ cwd, packageManager });
+      });
 
-    it('"prepare" built the addon', async () => {
-      let contents = await dirContents(distDir);
+      afterAll(async () => {
+        fs.rm(tmpDir, { recursive: true });
+      });
 
-      expect(contents).to.deep.equal(['index.js']);
-    });
+      it('is using the correct packager', async () => {
+        let npm = path.join(cwd, 'package-lock.json');
+        let yarn = path.join(cwd, 'yarn.lock');
+        let pnpm = path.join(cwd, 'pnpm-lock.yaml');
 
-    it('was generated correctly', async () => {
-      assertGeneratedCorrectly({ projectRoot: cwd });
-    });
+        switch (packageManager) {
+          case 'npm': {
+            expect(await fse.pathExists(npm), 'for NPM: package-lock.json exists').toBe(true);
+            expect(await fse.pathExists(yarn), 'yarn.lock does not exist').toBe(false);
+            expect(await fse.pathExists(pnpm), 'pnpm-lock.yaml does not exist').toBe(false);
 
-    it('builds the addon', async () => {
-      let { exitCode } = await runScript({ cwd, script: 'build' });
+            break;
+          }
+          case 'yarn': {
+            expect(await fse.pathExists(yarn), 'for Yarn: yarn.lock exists').toBe(true);
+            expect(await fse.pathExists(npm), 'package-lock.json does not exist').toBe(false);
+            expect(await fse.pathExists(pnpm), 'pnpm-lock.yaml does not exist').toBe(false);
 
-      expect(exitCode).toEqual(0);
-    });
+            break;
+          }
+          case 'pnpm': {
+            expect(await fse.pathExists(pnpm), 'for pnpm: pnpm-lock.yaml exists').toBe(true);
+            expect(await fse.pathExists(npm), 'package-lock.json does not exist').toBe(false);
+            expect(await fse.pathExists(yarn), 'yarn.lock does not exist').toBe(false);
 
-    it('runs tests', async () => {
-      let { exitCode } = await runScript({ cwd, script: 'test' });
+            break;
+          }
 
-      expect(exitCode).toEqual(0);
-    });
+          default:
+            throw new Error(`unknown packageManager: ${packageManager}`);
+        }
+      });
 
-    it('lints all pass', async () => {
-      let { exitCode } = await runScript({ cwd, script: 'lint' });
+      it('"prepare" built the addon', async () => {
+        let contents = await dirContents(distDir);
 
-      expect(exitCode).toEqual(0);
+        expect(contents).to.deep.equal(['index.js']);
+      });
+
+      it('was generated correctly', async () => {
+        assertGeneratedCorrectly({ projectRoot: cwd });
+      });
+
+      it('builds the addon', async () => {
+        let { exitCode } = await runScript({ cwd, script: 'build', packageManager });
+
+        expect(exitCode).toEqual(0);
+      });
+
+      it('runs tests', async () => {
+        let { exitCode } = await runScript({ cwd, script: 'test', packageManager });
+
+        expect(exitCode).toEqual(0);
+      });
+
+      it('lints all pass', async () => {
+        let { exitCode } = await runScript({ cwd, script: 'lint', packageManager });
+
+        expect(exitCode).toEqual(0);
+      });
     });
   });
 
@@ -89,13 +130,13 @@ describe('ember addon <the addon> -b <this blueprint>', () => {
       location = 'packages/my-custom-location';
 
       let { name } = await createAddon({
-        args: [`--addon-location=${location}`],
+        args: [`--addon-location=${location}`, '--pnpm=true'],
         options: { cwd: tmpDir },
       });
 
       cwd = path.join(tmpDir, name);
 
-      await install({ cwd });
+      await install({ cwd, packageManager: 'pnpm' });
     });
 
     afterAll(async () => {
@@ -107,13 +148,13 @@ describe('ember addon <the addon> -b <this blueprint>', () => {
     });
 
     it('runs tests', async () => {
-      let { exitCode } = await runScript({ cwd, script: 'test' });
+      let { exitCode } = await runScript({ cwd, script: 'test', packageManager: 'pnpm' });
 
       expect(exitCode).toEqual(0);
     });
 
     it('lints all pass', async () => {
-      let { exitCode } = await runScript({ cwd, script: 'lint' });
+      let { exitCode } = await runScript({ cwd, script: 'lint', packageManager: 'pnpm' });
 
       expect(exitCode).toEqual(0);
     });
@@ -129,13 +170,13 @@ describe('ember addon <the addon> -b <this blueprint>', () => {
       location = 'packages/my-custom-location';
 
       let { name } = await createAddon({
-        args: [`--test-app-location=${location}`],
+        args: [`--test-app-location=${location}`, '--pnpm=true'],
         options: { cwd: tmpDir },
       });
 
       cwd = path.join(tmpDir, name);
 
-      await install({ cwd });
+      await install({ cwd, packageManager: 'pnpm' });
     });
 
     afterAll(async () => {
@@ -147,13 +188,13 @@ describe('ember addon <the addon> -b <this blueprint>', () => {
     });
 
     it('runs tests', async () => {
-      let { exitCode } = await runScript({ cwd, script: 'test' });
+      let { exitCode } = await runScript({ cwd, script: 'test', packageManager: 'pnpm' });
 
       expect(exitCode).toEqual(0);
     });
 
     it('lints all pass', async () => {
-      let { exitCode } = await runScript({ cwd, script: 'lint' });
+      let { exitCode } = await runScript({ cwd, script: 'lint', packageManager: 'pnpm' });
 
       expect(exitCode).toEqual(0);
     });

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -59,7 +59,7 @@ describe('ember addon <the addon> -b <this blueprint>', () => {
       });
 
       afterAll(async () => {
-        fs.rm(tmpDir, { recursive: true });
+        fs.rm(tmpDir, { recursive: true, force: true });
       });
 
       it('is using the correct packager', async () => {
@@ -145,7 +145,7 @@ describe('ember addon <the addon> -b <this blueprint>', () => {
     });
 
     afterAll(async () => {
-      fs.rm(tmpDir, { recursive: true });
+      fs.rm(tmpDir, { recursive: true, force: true });
     });
 
     it('was generated correctly', async () => {
@@ -185,7 +185,7 @@ describe('ember addon <the addon> -b <this blueprint>', () => {
     });
 
     afterAll(async () => {
-      fs.rm(tmpDir, { recursive: true });
+      fs.rm(tmpDir, { recursive: true, force: true });
     });
 
     it('was generated correctly', async () => {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -28,10 +28,15 @@ describe('ember addon <the addon> -b <this blueprint>', () => {
       options
     );
 
+    // Light work-around for an upstream `@babel/core` peer issue
+    if (typeof options.cwd === 'string') {
+      await fs.writeFile(path.join(options.cwd, name, '.npmrc'), 'auto-install-peers=true');
+    }
+
     return { result, name };
   }
 
-  ['npm', 'yarn' /*, 'pnpm' */].map((packageManager) => {
+  ['npm', 'yarn', 'pnpm'].map((packageManager) => {
     describe(`defaults with ${packageManager}`, () => {
       let cwd = '';
       let tmpDir = '';

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -19,18 +19,7 @@ export async function install({ cwd, packageManager }: { cwd: string; packageMan
   if (packageManager === 'yarn') {
     await execa('yarn', ['install', '--non-interactive'], { cwd });
   } else {
-    if (packageManager === 'pnpm') {
-      /**
-       * This is needed because the app, when generated with pnpm,
-       * does not have correct deps - a peer is missing, @babel/core.
-       * and because the app blueprint is the second blueprint we invoke
-       * in this blueprint,we can't add dependencies to it.
-       */
-      await fs.writeFile(path.join(cwd, '.npmrc'), 'auto-install-peers=true');
-      await execa('pnpm', ['install'], { cwd });
-    } else {
-      await execa(packageManager, ['install'], { cwd });
-    }
+    await execa(packageManager, ['install'], { cwd });
   }
 
   // in order to test prepare, we need to have ignore-scripts=false

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -20,28 +20,21 @@ export async function install({ cwd, packageManager }: { cwd: string; packageMan
     await execa('yarn', ['install', '--non-interactive'], { cwd });
   } else {
     if (packageManager === 'pnpm') {
-      try {
-        await execa('pnpm', ['install'], { cwd });
-      } catch (e) {
-        /**
-         * This is needed because the app, when generated with pnpm,
-         * does not have correct deps - a peer is missing, @babel/core.
-         * and because the app blueprint is the second blueprint we invoke
-         * in this blueprint,we can't add dependencies to it.
-         */
-        if (e instanceof Error && e.message.includes('pnpm install')) {
-          return;
-        }
-
-        throw e;
-      }
+      /**
+       * This is needed because the app, when generated with pnpm,
+       * does not have correct deps - a peer is missing, @babel/core.
+       * and because the app blueprint is the second blueprint we invoke
+       * in this blueprint,we can't add dependencies to it.
+       */
+      await fs.writeFile(path.join(cwd, '.npmrc'), 'auto-install-peers=true');
+      await execa('pnpm', ['install'], { cwd });
     } else {
       await execa(packageManager, ['install'], { cwd });
     }
   }
 
   // in order to test prepare, we need to have ignore-scripts=false
-  // this is a security risk so we'll manually invoke install + prepare
+  // which is a security risk so we'll manually invoke install + prepare
   await execa(packageManager, ['run', 'prepare'], { cwd });
 }
 

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -19,7 +19,18 @@ export async function install({ cwd, packageManager }: { cwd: string; packageMan
   if (packageManager === 'yarn') {
     await execa('yarn', ['install', '--non-interactive'], { cwd });
   } else {
-    await execa(packageManager, ['install'], { cwd });
+    try {
+      await execa(packageManager, ['install'], { cwd });
+    } catch (e) {
+      if (packageManager === 'pnpm') {
+        console.info('An error occurred. Are there still upstream issues to resolve?');
+        console.error(e);
+
+        return;
+      }
+
+      throw e;
+    }
   }
 
   // in order to test prepare, we need to have ignore-scripts=false


### PR DESCRIPTION
The current released version of the addon-blueprint only provides `yarn`.

This PR:
 - adds the ability to use npm workspaces
 - adds the ability to pnpm workspaces
 - adds tests for npm, pnpm, and yarn 
 - keeps `scripts` commands/behavior between the 3 package managers the same
 
 
 Closes: https://github.com/embroider-build/addon-blueprint/issues/35