### PR TITLE
Switch to Concurrently from npm-run-all

### DIFF
--- a/files/__addonLocation__/package.json
+++ b/files/__addonLocation__/package.json
@@ -14,15 +14,15 @@
   ],
   "scripts": {
     "build": "rollup --config",
-    "lint": "npm-run-all --aggregate-output --continue-on-error --parallel \"lint:!(fix)\"",
-    "lint:fix": "npm-run-all --aggregate-output --continue-on-error --parallel lint:*:fix",
+    "lint": "concurrently 'npm:lint:*(!fix)' --names 'lint:'",
+    "lint:fix": "concurrently 'npm:lint:*:fix' --names 'fix:'",
     "lint:hbs": "ember-template-lint . --no-error-on-unmatched-pattern",
-    "lint:hbs:fix": "ember-template-lint . --fix --no-error-on-unmatched-pattern",
     "lint:js": "eslint . --cache",
+    "lint:hbs:fix": "ember-template-lint . --fix --no-error-on-unmatched-pattern",
     "lint:js:fix": "eslint . --fix",
     "start": "rollup --config --watch",
     "test": "echo 'A v2 addon does not have tests, run tests in test-app'",
-    "prepare": "yarn build"
+    "prepublishOnly": "rollup --config"
   },
   "dependencies": {
     "@embroider/addon-shim": "^1.0.0"
@@ -35,13 +35,13 @@
     "@babel/plugin-syntax-decorators": "^7.17.0",
     "@embroider/addon-dev": "^1.0.0",
     "@rollup/plugin-babel": "^5.3.0",
+    "concurrently": "^7.2.1",
     "ember-template-lint": "^4.0.0",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-ember": "^10.5.8",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^4.0.0",
-    "npm-run-all": "^4.1.5",
     "rollup": "^2.67.0"
   },
   "publishConfig": {

--- a/files/package.json
+++ b/files/package.json
@@ -5,24 +5,20 @@
   "license": "MIT",
   "author": "",
   "scripts": {
-    "prepare": "yarn workspace <%= addonName %> run prepare",
-    "start": "npm-run-all --parallel start:*",
+    "prepare": "yarn build",
+    "build": "yarn workspace <%= addonName %> run build",
+
+    "start": "concurrently 'npm:start:*' --restart-after 5000 --prefix-colors cyan,white,yellow",
     "start:addon": "yarn workspace <%= addonName %> run start",
-    "start:test-app": "yarn workspace test-app run start",
-    "lint": "npm-run-all --aggregate-output --continue-on-error --parallel \"lint:!(fix)\"",
-    "lint:addon": "yarn workspace <%= addonName %> run lint",
-    "lint:test-app": "yarn workspace test-app run lint",
-    "lint:fix": "npm-run-all --aggregate-output --continue-on-error --parallel lint:fix:*",
-    "lint:fix:addon": "yarn workspace <%= addonName %> run lint:fix",
-    "lint:fix:test-app": "yarn workspace test-app run lint:fix",
-    "test": "npm-run-all --aggregate-output --continue-on-error --parallel \"test:!(watch)\"",
-    "test:watch": "npm-run-all --aggregate-output --continue-on-error --parallel test:watch:*",
-    "test:test-app": "yarn workspace test-app run test",
-    "test:watch:test-app": "yarn workspace test-app run test:watch",
-    "test:watch:addon": "yarn workspace <%= addonName %> run start"
+    "start:test": "yarn workspace <%= testAppInfo.name.dashed %> run start",
+
+    "lint": "yarn workspaces run lint",
+    "lint:fix": "yarn workspaces run lint:fix",
+
+    "test": "yarn workspace <%= testAppInfo.name.dashed %> run test"
   },
   "devDependencies": {
-    "npm-run-all": "^4.1.5",
+    "concurrently": "^7.2.1",
     "prettier": "^2.5.1"
   },
   "workspaces": [

--- a/files/package.json
+++ b/files/package.json
@@ -15,7 +15,7 @@
     "lint": "yarn workspaces run lint",
     "lint:fix": "yarn workspaces run lint:fix",
 
-    "test": "yarn workspace <%= testAppInfo.name.dashed %> run test"
+    "test": "yarn workspaces run test"
   },
   "devDependencies": {
     "concurrently": "^7.2.1",


### PR DESCRIPTION
This will be a pre-req for: https://github.com/embroider-build/addon-blueprint/pull/36

Why concurrently?
 - prefixed logs (easier to tell what's logging from what command)
 - way less --flag boilerplate
 - actually maintained
 - prefixing works well with pnpm's task prefixing as well
 
 The test-app's scripts are still npm-run-all as they're inheriting from the upstream blueprint. #36 will fix that, as the way scripts are assigned is changing entirely in that PR.