### PR TITLE
Add Typescript support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - main
   schedule:
-    - cron: "0 3 * * 0" # every Sunday at 3am
+    - cron: '0 3 * * 0' # every Sunday at 3am
 
 env:
   CI: true
@@ -22,7 +22,7 @@ jobs:
         run: pnpm lint
 
   test_type_checking:
-    name: "Tests: Type Check"
+    name: 'Tests: Type Check'
     timeout-minutes: 5
     runs-on: ubuntu-latest
 
@@ -47,10 +47,10 @@ jobs:
           - defaults with pnpm
           - addon-location
           - test-app-location
+          - typescript
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/pnpm
       - run: pnpm add --global ember-cli yarn
       - run: pnpm vitest --testNamePattern "${{ matrix.slow-test }}"
         working-directory: tests
-

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -2,4 +2,5 @@
 
 module.exports = {
   singleQuote: true,
+  printWidth: 100,
 };

--- a/files/__addonLocation__/.eslintrc.js
+++ b/files/__addonLocation__/.eslintrc.js
@@ -4,14 +4,14 @@ module.exports = {
   root: true,
   parser: '<%= typescript ? '@typescript-eslint/parser' : '@babel/eslint-parser' %>',
   parserOptions: {
-    ecmaVersion: 'latest',
+    ecmaVersion: 'latest',<% if (!typescript) { %>
     sourceType: 'module',
     ecmaFeatures: {
       legacyDecorators: true,
     },
     babelOptions: {
       root: __dirname,
-    },
+    },<% } %>
   },
   plugins: ['ember'],
   extends: [

--- a/files/__addonLocation__/.eslintrc.js
+++ b/files/__addonLocation__/.eslintrc.js
@@ -2,7 +2,7 @@
 
 module.exports = {
   root: true,
-  parser: '@babel/eslint-parser',
+  parser: '<%= typescript ? '@typescript-eslint/parser' : '@babel/eslint-parser' %>',
   parserOptions: {
     ecmaVersion: 'latest',
     sourceType: 'module',
@@ -24,7 +24,18 @@ module.exports = {
   },
   rules: {},
   overrides: [
-    // node files
+<% if (typescript) { %>    // ts files
+    {
+      files: ['**/*.ts'],
+      extends: [
+        'plugin:@typescript-eslint/eslint-recommended',
+        'plugin:@typescript-eslint/recommended',
+      ],
+      rules: {
+        // Add any custom rules here
+      },
+    },
+<% } %>    // node files
     {
       files: [
         './.eslintrc.js',

--- a/files/__addonLocation__/babel.config.json
+++ b/files/__addonLocation__/babel.config.json
@@ -1,5 +1,6 @@
 {
-  "plugins": [
+<% if (typescript) { %>  "presets": [["@babel/preset-typescript"]],
+<% } %>  "plugins": [
     "@embroider/addon-dev/template-colocation-plugin",
     ["@babel/plugin-proposal-decorators", { "legacy": true }],
     "@babel/plugin-proposal-class-properties"

--- a/files/__addonLocation__/package.json
+++ b/files/__addonLocation__/package.json
@@ -35,8 +35,8 @@
     "@babel/plugin-proposal-decorators": "^7.17.0",
     "@babel/plugin-syntax-decorators": "^7.17.0",
     "@embroider/addon-dev": "^2.0.0",<% if (typescript) { %>
-    "@glint/core": "^0.9.1",
-    "@glint/environment-ember-loose": "^0.9.1",
+    "@glint/core": "^0.9.7",
+    "@glint/environment-ember-loose": "^0.9.7",
     "@tsconfig/ember": "^1.0.0",
     "@types/ember": "^4.0.0",
     "@types/ember__object": "^4.0.0",

--- a/files/__addonLocation__/package.json
+++ b/files/__addonLocation__/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.17.0",
-    <% if (typescript) { %>"@babel/preset-typescript": "7.18.6"<% } else { %>"@babel/eslint-parser": "^7.18.2"<% } %>,
+    <% if (typescript) { %>"@babel/preset-typescript": "^7.18.6"<% } else { %>"@babel/eslint-parser": "^7.18.2"<% } %>,
     "@babel/plugin-proposal-class-properties": "^7.16.7",
     "@babel/plugin-proposal-decorators": "^7.17.0",
     "@babel/plugin-syntax-decorators": "^7.17.0",
@@ -56,8 +56,8 @@
     "@types/ember__component": "^4.0.0",
     "@types/ember__routing": "^4.0.0",
     "@types/ember__test-helpers": "^2.6.1",
-    "@typescript-eslint/eslint-plugin": "5.30.5",
-    "@typescript-eslint/parser": "5.30.5",<% } else { %>
+    "@typescript-eslint/eslint-plugin": "^5.30.5",
+    "@typescript-eslint/parser": "^5.30.5",<% } else { %>
     "@rollup/plugin-babel": "^5.3.0",<% } %>
     "concurrently": "^7.2.1",
     "ember-template-lint": "^4.0.0",

--- a/files/__addonLocation__/package.json
+++ b/files/__addonLocation__/package.json
@@ -19,7 +19,8 @@
     "lint:hbs": "ember-template-lint . --no-error-on-unmatched-pattern",
     "lint:js": "eslint . --cache",
     "lint:hbs:fix": "ember-template-lint . --fix --no-error-on-unmatched-pattern",
-    "lint:js:fix": "eslint . --fix",
+    "lint:js:fix": "eslint . --fix",<% if (typescript) { %>
+    "lint:ts": "glint",<% } %>
     "start": "rollup --config --watch",
     "test": "echo 'A v2 addon does not have tests, run tests in test-app'",
     "prepack": "rollup --config"
@@ -54,6 +55,7 @@
     "@types/ember__error": "^4.0.0",
     "@types/ember__component": "^4.0.0",
     "@types/ember__routing": "^4.0.0",
+    "@types/ember__test-helpers": "^2.6.1",
     "@typescript-eslint/eslint-plugin": "5.30.5",
     "@typescript-eslint/parser": "5.30.5",<% } else { %>
     "@rollup/plugin-babel": "^5.3.0",<% } %>

--- a/files/__addonLocation__/package.json
+++ b/files/__addonLocation__/package.json
@@ -29,12 +29,34 @@
   },
   "devDependencies": {
     "@babel/core": "^7.17.0",
-    "@babel/eslint-parser": "^7.18.2",
+    <% if (typescript) { %>"@babel/preset-typescript": "7.18.6"<% } else { %>"@babel/eslint-parser": "^7.18.2"<% } %>,
     "@babel/plugin-proposal-class-properties": "^7.16.7",
     "@babel/plugin-proposal-decorators": "^7.17.0",
     "@babel/plugin-syntax-decorators": "^7.17.0",
-    "@embroider/addon-dev": "^1.0.0",
-    "@rollup/plugin-babel": "^5.3.0",
+    "@embroider/addon-dev": "^1.0.0",<% if (typescript) { %>
+    "@glint/core": "^0.9.1",
+    "@glint/environment-ember-loose": "^0.9.1",
+    "@tsconfig/ember": "^1.0.0",
+    "@types/ember": "^4.0.0",
+    "@types/ember__object": "^4.0.0",
+    "@types/ember__service": "^4.0.0",
+    "@types/ember__controller": "^4.0.0",
+    "@types/ember__string": "^3.16.0",
+    "@types/ember__template": "^4.0.0",
+    "@types/ember__polyfills": "^4.0.0",
+    "@types/ember__utils": "^4.0.0",
+    "@types/ember__runloop": "^4.0.0",
+    "@types/ember__debug": "^4.0.0",
+    "@types/ember__engine": "^4.0.0",
+    "@types/ember__application": "^4.0.0",
+    "@types/ember__test": "^4.0.0",
+    "@types/ember__array": "^4.0.0",
+    "@types/ember__error": "^4.0.0",
+    "@types/ember__component": "^4.0.0",
+    "@types/ember__routing": "^4.0.0",
+    "@typescript-eslint/eslint-plugin": "5.30.5",
+    "@typescript-eslint/parser": "5.30.5",<% } else { %>
+    "@rollup/plugin-babel": "^5.3.0",<% } %>
     "concurrently": "^7.2.1",
     "ember-template-lint": "^4.0.0",
     "eslint": "^7.32.0",
@@ -44,7 +66,9 @@
     "eslint-plugin-prettier": "^4.0.0",
     "prettier": "^2.5.1",
     "rollup": "^2.67.0",
-    "rollup-plugin-copy": "^3.4.0"
+    "rollup-plugin-copy": "^3.4.0"<% if (typescript) { %>,
+    "rollup-plugin-ts": "^3.0.2",
+    "typescript": "^4.7.4"<% } %>
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"
@@ -58,8 +82,19 @@
     "main": "addon-main.js"
   },
   "exports": {
-    ".": "./dist/index.js",
-    "./*": "./dist/*",
+    ".": "./dist/index.js", <% if (typescript) { %>
+    "./*": {
+      "types": "./dist/*.d.ts",
+      "default": "./dist/*.js"
+    },<% } else { %>
+    "./*": "./dist/*.js",<% } %>
     "./addon-main.js": "./addon-main.js"
-  }
+  }<% if (typescript) { %>,
+  "typesVersions": {
+    "*": {
+      "*": [
+        "dist/*"
+      ]
+    }
+  }<% } %>
 }

--- a/files/__addonLocation__/package.json
+++ b/files/__addonLocation__/package.json
@@ -34,7 +34,7 @@
     "@babel/plugin-proposal-class-properties": "^7.16.7",
     "@babel/plugin-proposal-decorators": "^7.17.0",
     "@babel/plugin-syntax-decorators": "^7.17.0",
-    "@embroider/addon-dev": "^1.0.0",<% if (typescript) { %>
+    "@embroider/addon-dev": "^2.0.0",<% if (typescript) { %>
     "@glint/core": "^0.9.1",
     "@glint/environment-ember-loose": "^0.9.1",
     "@tsconfig/ember": "^1.0.0",

--- a/files/__addonLocation__/package.json
+++ b/files/__addonLocation__/package.json
@@ -20,7 +20,7 @@
     "lint:js": "eslint . --cache",
     "lint:hbs:fix": "ember-template-lint . --fix --no-error-on-unmatched-pattern",
     "lint:js:fix": "eslint . --fix",<% if (typescript) { %>
-    "lint:ts": "glint",<% } %>
+    "lint:types": "glint",<% } %>
     "start": "rollup --config --watch",
     "test": "echo 'A v2 addon does not have tests, run tests in test-app'",
     "prepack": "rollup --config"

--- a/files/__addonLocation__/rollup.config.__rollupExt__
+++ b/files/__addonLocation__/rollup.config.__rollupExt__
@@ -15,7 +15,7 @@ export default {
   plugins: [
     // These are the modules that users should be able to import from your
     // addon. Anything not listed here may get optimized away.
-    addon.publicEntrypoints(['components/**/*.js', 'index.js'<% if (typescript) {%>, 'glint.js'<% } %>]),
+    addon.publicEntrypoints(['components/**/*.js', 'index.js'<% if (typescript) {%>, 'template-registry.js'<% } %>]),
 
     // These are the modules that should get reexported into the traditional
     // "app" tree. Things in here should also be in publicEntrypoints above, but

--- a/files/__addonLocation__/rollup.config.__rollupExt__
+++ b/files/__addonLocation__/rollup.config.__rollupExt__
@@ -15,7 +15,7 @@ export default {
   plugins: [
     // These are the modules that users should be able to import from your
     // addon. Anything not listed here may get optimized away.
-    addon.publicEntrypoints(['components/**/*.<%= ext %>', 'index.<%= ext %>'<% if (typescript) {%>, 'glint.ts'<% } %>]),
+    addon.publicEntrypoints(['components/**/*.js', 'index.js'<% if (typescript) {%>, 'glint.js'<% } %>]),
 
     // These are the modules that should get reexported into the traditional
     // "app" tree. Things in here should also be in publicEntrypoints above, but

--- a/files/__addonLocation__/rollup.config.__rollupExt__
+++ b/files/__addonLocation__/rollup.config.__rollupExt__
@@ -1,4 +1,4 @@
-import babel from '@rollup/plugin-babel';
+<% if (typescript) { %>import typescript from 'rollup-plugin-ts';<% } else { %>import babel from '@rollup/plugin-babel';<% } %>
 import copy from 'rollup-plugin-copy';
 import { Addon } from '@embroider/addon-dev/rollup';
 
@@ -15,14 +15,20 @@ export default {
   plugins: [
     // These are the modules that users should be able to import from your
     // addon. Anything not listed here may get optimized away.
-    addon.publicEntrypoints(['components/**/*.js', 'index.js']),
+    addon.publicEntrypoints(['components/**/*.<%= ext %>', 'index.<%= ext %>'<% if (typescript) {%>, 'glint.ts'<% } %>]),
 
     // These are the modules that should get reexported into the traditional
     // "app" tree. Things in here should also be in publicEntrypoints above, but
     // not everything in publicEntrypoints necessarily needs to go here.
     addon.appReexports(['components/**/*.js']),
 
-    // This babel config should *not* apply presets or compile away ES modules.
+<% if (typescript) { %>    // compile TypeScript to latest JavaScript, including Babel transpilation
+    typescript({
+      transpiler: 'babel',
+      browserslist: false,
+      transpileOnly: false,
+    }),
+<% } else { %>    // This babel config should *not* apply presets or compile away ES modules.
     // It exists only to provide development niceties for you, like automatic
     // template colocation.
     //
@@ -31,7 +37,7 @@ export default {
     babel({
       babelHelpers: 'bundled',
     }),
-
+<% } %>
     // Follow the V2 Addon rules about dependencies. Your code can import from
     // `dependencies` and `peerDependencies` as well as standard Ember-provided
     // package names.

--- a/files/__addonLocation__/src/glint.ts
+++ b/files/__addonLocation__/src/glint.ts
@@ -1,0 +1,13 @@
+// Easily allow apps, which are not yet using strict mode templates, to consume your Glint types, by importing this file.
+// Add all your components, helpers and modifiers to the template registry here, so apps don't have to do this.
+// See https://typed-ember.gitbook.io/glint/using-glint/ember/authoring-addons
+
+// import type MyComponent from './components/my-component';
+
+declare module '@glint/environment-ember-loose/registry' {
+  // Remove this once entries have been added! 👇
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface
+  export default interface Registry {
+    // MyComponent: typeof MyComponent
+  }
+}

--- a/files/__addonLocation__/src/template-registry.ts
+++ b/files/__addonLocation__/src/template-registry.ts
@@ -4,10 +4,8 @@
 
 // import type MyComponent from './components/my-component';
 
-declare module '@glint/environment-ember-loose/registry' {
-  // Remove this once entries have been added! 👇
-  // eslint-disable-next-line @typescript-eslint/no-empty-interface
-  export default interface Registry {
-    // MyComponent: typeof MyComponent
-  }
+// Remove this once entries have been added! 👇
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export default interface Registry {
+  // MyComponent: typeof MyComponent
 }

--- a/files/__addonLocation__/tsconfig.json
+++ b/files/__addonLocation__/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "@tsconfig/ember/tsconfig.json",
+  "compilerOptions": {
+    "paths": {
+      // No paths, no absolute imports, only node_modules imports allowed
+      // But fallback for type-overrides and such
+      "*": ["types/*"]
+    }
+  },
+  "include": [
+    "src/**/*",
+    "types/**/*"
+  ]
+}

--- a/files/__addonLocation__/tsconfig.json
+++ b/files/__addonLocation__/tsconfig.json
@@ -10,5 +10,11 @@
   "include": [
     "src/**/*",
     "types/**/*"
-  ]
+  ],
+  "glint": {
+    "environment": "ember-loose",
+    "transform": {
+      "include": ["src/**"]
+    }
+  }
 }

--- a/files/__addonLocation__/tsconfig.json
+++ b/files/__addonLocation__/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "@tsconfig/ember/tsconfig.json",
   "include": [
     "src/**/*",
-    "types/**/*"
+    "unpublished-development-types/**/*"
   ],
   "glint": {
     "environment": "ember-loose"

--- a/files/__addonLocation__/tsconfig.json
+++ b/files/__addonLocation__/tsconfig.json
@@ -1,20 +1,10 @@
 {
   "extends": "@tsconfig/ember/tsconfig.json",
-  "compilerOptions": {
-    "paths": {
-      // No paths, no absolute imports, only node_modules imports allowed
-      // But fallback for type-overrides and such
-      "*": ["types/*"]
-    }
-  },
   "include": [
     "src/**/*",
     "types/**/*"
   ],
   "glint": {
-    "environment": "ember-loose",
-    "transform": {
-      "include": ["src/**"]
-    }
+    "environment": "ember-loose"
   }
 }

--- a/files/__addonLocation__/types/glint.d.ts
+++ b/files/__addonLocation__/types/glint.d.ts
@@ -1,0 +1,10 @@
+import '@glint/environment-ember-loose';
+
+declare module '@glint/environment-ember-loose/registry' {
+  // Remove this once entries have been added! 👇
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface
+  export default interface Registry {
+    // Add any registry entries from other addons here that your addon itself uses (in non-strict mode templates)
+    // See https://typed-ember.gitbook.io/glint/using-glint/ember/using-addons
+  }
+}

--- a/files/__addonLocation__/unpublished-development-types/index.d.ts
+++ b/files/__addonLocation__/unpublished-development-types/index.d.ts
@@ -1,3 +1,6 @@
+// Add any types here that you need for local development only.
+// These will *not* be published as part of your addon, so be careful that your published code does not rely on them!
+
 import '@glint/environment-ember-loose';
 
 declare module '@glint/environment-ember-loose/registry' {

--- a/index.js
+++ b/index.js
@@ -105,11 +105,13 @@ module.exports = {
   },
 
   fileMapTokens(options) {
-    let { addonInfo, testAppInfo } = options.locals;
+    let { addonInfo, testAppInfo, ext, typescript } = options.locals;
 
     return {
       __addonLocation__: () => addonInfo.location,
       __testAppLocation__: () => testAppInfo.location,
+      __ext__: () => ext,
+      __rollupExt__: () => (typescript ? 'mjs' : 'js'),
     };
   },
 
@@ -158,11 +160,27 @@ module.exports = {
       pnpm: options.pnpm,
       npm: options.npm,
       welcome: options.welcome,
+      typescript: options.typescript,
+      ext: options.typescript ? 'ts' : 'js',
       blueprint: 'addon',
       blueprintOptions,
       ciProvider: options.ciProvider,
       pathFromAddonToRoot,
     };
+  },
+
+  files(options) {
+    let files = this._super.files.apply(this, arguments);
+
+    if (options.typescript) {
+      return files;
+    } else {
+      let ignoredFiles = ['__addonLocation__/tsconfig.json'];
+      return files.filter(
+        (filename) =>
+          !filename.match(/.*\.ts$/) && !ignoredFiles.includes(filename)
+      );
+    }
   },
 
   normalizeEntityName(entityName) {

--- a/index.js
+++ b/index.js
@@ -93,7 +93,7 @@ module.exports = {
   },
 
   async updateTestAppPackageJson(packageJsonPath) {
-    const pkg = require(packageJsonPath);
+    const pkg = await fs.readJSON(packageJsonPath);
     const additions = require('./additional-test-app-package.json');
 
     merge(pkg, additions);

--- a/index.js
+++ b/index.js
@@ -22,6 +22,8 @@ module.exports = {
 
   async afterInstall(options) {
     let tasks = [this.createTestApp(options)];
+    let addonInfo = addonInfoFromOptions(options);
+    let testAppInfo = testAppInfoFromOptions(options);
 
     /**
      * Setup root package.json scripts based on the packager
@@ -55,7 +57,6 @@ module.exports = {
       throw new SilentError('Cannot find app blueprint for generating test-app!');
     }
 
-    let addonInfo = addonInfoFromOptions(options);
     let testAppInfo = testAppInfoFromOptions(options);
     let testAppPath = path.join(options.target, testAppInfo.location);
 

--- a/index.js
+++ b/index.js
@@ -175,6 +175,7 @@ module.exports = {
             `"--test-app-location=${options.testAppLocation}"`,
           options.testAppName && `"--test-app-name=${options.testAppName}"`,
           options.releaseIt && `"--release-it"`,
+          options.typescript && `"--typescript"`,
         ]
           .filter(Boolean)
           .join(',\n            ') +
@@ -213,9 +214,9 @@ module.exports = {
       return files;
     } else {
       let ignoredFiles = ['__addonLocation__/tsconfig.json'];
+
       return files.filter(
-        (filename) =>
-          !filename.match(/.*\.ts$/) && !ignoredFiles.includes(filename)
+        (filename) => !filename.match(/.*\.ts$/) && !ignoredFiles.includes(filename)
       );
     }
   },

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "execa": "^5.1.1",
     "fs-extra": "^10.0.0",
     "lodash": "^4.17.21",
+    "semver": "^7.3.8",
     "silent-error": "^1.1.1",
     "sort-package-json": "^1.54.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,7 @@ importers:
       lodash: ^4.17.21
       prettier: ^2.5.1
       release-it: ^15.5.0
+      semver: ^7.3.8
       silent-error: ^1.1.1
       sort-package-json: ^1.54.0
       typescript: ^4.7.4
@@ -29,6 +30,7 @@ importers:
       execa: 5.1.1
       fs-extra: 10.1.0
       lodash: 4.17.21
+      semver: 7.3.8
       silent-error: 1.1.1
       sort-package-json: 1.57.0
     devDependencies:
@@ -307,7 +309,7 @@ packages:
     resolution: {integrity: sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==}
     dependencies:
       '@gar/promisify': 1.1.3
-      semver: 7.3.7
+      semver: 7.3.8
     dev: true
 
   /@npmcli/move-file/1.1.2:
@@ -634,7 +636,7 @@ packages:
       functional-red-black-tree: 1.0.1
       ignore: 5.2.0
       regexpp: 3.2.0
-      semver: 7.3.7
+      semver: 7.3.8
       tsutils: 3.21.0_typescript@4.7.4
       typescript: 4.7.4
     transitivePeerDependencies:
@@ -727,7 +729,7 @@ packages:
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.3.7
+      semver: 7.3.8
       tsutils: 3.21.0_typescript@4.7.4
       typescript: 4.7.4
     transitivePeerDependencies:
@@ -1134,8 +1136,8 @@ packages:
     engines: {node: '>=14.16'}
     dev: true
 
-  /cacheable-request/10.2.1:
-    resolution: {integrity: sha512-3tLJyBjGuXw1s5gpKFSG3iS4kaKT4id04dZi98wzHQp/8cqZNweBnrF9J+rrlvrf4M53OdtDGNctNHFias8BEA==}
+  /cacheable-request/10.2.2:
+    resolution: {integrity: sha512-KxjQZM3UIo7/J6W4sLpwFvu1GB3Whv8NtZ8ZrUL284eiQjiXeeqWTdhixNrp/NLZ/JNuFBo6BD4ZaO8ZJ5BN8Q==}
     engines: {node: '>=14.16'}
     dependencies:
       '@types/http-cache-semantics': 4.0.1
@@ -1396,7 +1398,7 @@ packages:
       github-label-sync: 1.6.0
       hosted-git-info: 3.0.8
       mdast-util-from-markdown: 0.8.5
-      semver: 7.3.7
+      semver: 7.3.8
       sort-package-json: 1.57.0
       which: 2.0.2
     transitivePeerDependencies:
@@ -2262,7 +2264,7 @@ packages:
       optionator: 0.9.1
       progress: 2.0.3
       regexpp: 3.2.0
-      semver: 7.3.7
+      semver: 7.3.8
       strip-ansi: 6.0.1
       strip-json-comments: 3.1.1
       table: 6.8.0
@@ -2815,7 +2817,7 @@ packages:
       '@sindresorhus/is': 5.3.0
       '@szmarczak/http-timer': 5.0.1
       cacheable-lookup: 7.0.0
-      cacheable-request: 10.2.1
+      cacheable-request: 10.2.2
       decompress-response: 6.0.0
       form-data-encoder: 2.1.3
       get-stream: 6.0.1
@@ -3554,7 +3556,7 @@ packages:
       make-fetch-happen: 9.1.0
       p-map: 3.0.0
       progress: 2.0.3
-      yargs: 17.6.0
+      yargs: 17.6.1
     transitivePeerDependencies:
       - bluebird
       - supports-color
@@ -4402,7 +4404,7 @@ packages:
       got: 12.5.1
       registry-auth-token: 5.0.1
       registry-url: 6.0.1
-      semver: 7.3.7
+      semver: 7.3.8
     dev: true
 
   /parent-module/1.0.1:
@@ -4922,7 +4924,7 @@ packages:
     resolution: {integrity: sha512-0Ju4+6A8iOnpL/Thra7dZsSlOHYAHIeMxfhWQRI1/VLcT3WDBZKKtQt/QkBOsiIN9ZpuvHE6cGZ0x4glCMmfiA==}
     engines: {node: '>=12'}
     dependencies:
-      semver: 7.3.7
+      semver: 7.3.8
     dev: true
 
   /semver/6.3.0:
@@ -4932,6 +4934,14 @@ packages:
 
   /semver/7.3.7:
     resolution: {integrity: sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      lru-cache: 6.0.0
+    dev: true
+
+  /semver/7.3.8:
+    resolution: {integrity: sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==}
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
@@ -5492,7 +5502,7 @@ packages:
       is-yarn-global: 0.4.0
       latest-version: 7.0.0
       pupa: 3.1.0
-      semver: 7.3.7
+      semver: 7.3.8
       semver-diff: 4.0.0
       xdg-basedir: 5.1.0
     dev: true
@@ -5558,7 +5568,7 @@ packages:
     engines: {node: '>= 12'}
     dependencies:
       resolve-package-path: 4.0.3
-      semver: 7.3.7
+      semver: 7.3.8
     dev: true
 
   /verror/1.10.0:
@@ -5814,8 +5824,8 @@ packages:
       yargs-parser: 20.2.9
     dev: true
 
-  /yargs/17.6.0:
-    resolution: {integrity: sha512-8H/wTDqlSwoSnScvV2N/JHfLWOKuh5MVla9hqLjK3nsfyy6Y4kDSYSvkU5YCUEPOSnRXfIyx3Sq+B/IWudTo4g==}
+  /yargs/17.6.1:
+    resolution: {integrity: sha512-leBuCGrL4dAd6ispNOGsJlhd0uZ6Qehkbu/B9KCR+Pxa/NVdNwi+i31lo0buCm6XxhJQFshXCD0/evfV4xfoUg==}
     engines: {node: '>=12'}
     dependencies:
       cliui: 8.0.1

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -164,13 +164,13 @@ describe('ember addon <the addon> -b <this blueprint>', () => {
       let contents = await dirContents(distDir);
 
       expect(contents).to.deep.equal([
-        'glint.d.ts',
-        'glint.d.ts.map',
-        'glint.js',
-        'glint.js.map',
         'index.d.ts',
+        'index.d.ts.map',
         'index.js',
         'index.js.map',
+        'template-registry.d.ts',
+        'template-registry.js',
+        'template-registry.js.map',
       ]);
     });
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -109,6 +109,10 @@ describe('ember addon <the addon> -b <this blueprint>', () => {
         let { exitCode } = await runScript({ cwd, script: 'build', packageManager });
 
         expect(exitCode).toEqual(0);
+
+        let contents = await dirContents(distDir);
+
+        expect(contents).to.deep.equal(['index.js', 'index.js.map']);
       });
 
       it('runs tests', async () => {
@@ -122,6 +126,64 @@ describe('ember addon <the addon> -b <this blueprint>', () => {
 
         expect(exitCode).toEqual(0);
       });
+    });
+  });
+
+  describe('--typescript', () => {
+    let cwd = '';
+    let tmpDir = '';
+    let distDir = '';
+
+    beforeAll(async () => {
+      tmpDir = await createTmp();
+
+      let { name } = await createAddon({
+        args: ['--typescript', '--yarn=true'],
+        options: { cwd: tmpDir },
+      });
+
+      cwd = path.join(tmpDir, name);
+      distDir = path.join(cwd, name, 'dist');
+
+      await install({ cwd, packageManager: 'yarn' });
+    });
+
+    afterAll(async () => {
+      fs.rm(tmpDir, { recursive: true, force: true });
+    });
+
+    it('was generated correctly', async () => {
+      assertGeneratedCorrectly({ projectRoot: cwd });
+    });
+
+    it('builds the addon', async () => {
+      let { exitCode } = await runScript({ cwd, script: 'build', packageManager: 'yarn' });
+
+      expect(exitCode).toEqual(0);
+
+      let contents = await dirContents(distDir);
+
+      expect(contents).to.deep.equal([
+        'glint.d.ts',
+        'glint.d.ts.map',
+        'glint.js',
+        'glint.js.map',
+        'index.d.ts',
+        'index.js',
+        'index.js.map',
+      ]);
+    });
+
+    it('runs tests', async () => {
+      let { exitCode } = await runScript({ cwd, script: 'test', packageManager: 'yarn' });
+
+      expect(exitCode).toEqual(0);
+    });
+
+    it('lints all pass', async () => {
+      let { exitCode } = await runScript({ cwd, script: 'lint', packageManager: 'yarn' });
+
+      expect(exitCode).toEqual(0);
     });
   });
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -149,7 +149,7 @@ describe('ember addon <the addon> -b <this blueprint>', () => {
     });
 
     afterAll(async () => {
-      fs.rm(tmpDir, { recursive: true, force: true });
+      await fs.rm(tmpDir, { recursive: true, force: true });
     });
 
     it('was generated correctly', async () => {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -98,7 +98,7 @@ describe('ember addon <the addon> -b <this blueprint>', () => {
       it('"prepare" built the addon', async () => {
         let contents = await dirContents(distDir);
 
-        expect(contents).to.deep.equal(['index.js']);
+        expect(contents).to.deep.equal(['index.js', 'index.js.map']);
       });
 
       it('was generated correctly', async () => {


### PR DESCRIPTION
Introduces the `--typescript` flag, closing #10.

Some notes:
* the rollup and babel config is for now what I used so far. Will update to agreed upon best practices as soon as https://github.com/embroider-build/embroider/pull/1099 is approved and merged! Therefore still a draft...
* ESLint is configured for TS. Again what I have been using commonly.
* `tsconfig.json` is using the [setup that `ember-cli-typescript` is also generating](https://github.com/typed-ember/ember-cli-typescript/blob/master/blueprint-files/ember-cli-typescript/tsconfig.json) recently, delegating to `@tsconfig/ember`.
* this also sets up the infrastructure for the addon to use and expose Glint types. Which isn't official, and hasn't been RFCed. But I figured people using the latest stuff here w/ TS will probably want it? 🤔 Can remove, if that seems too controversial. But I love it 😍. Or add an additional `--glint` flag? Related: https://typed-ember.gitbook.io/glint/using-glint/ember/authoring-addons and https://github.com/typed-ember/glint/issues/338
* the test-app generation delegates the `--typescript` flag to the official app blueprint (which in the latest canary version does support that as well). If the used Ember CLI version is not one that support it, then a warning message is shown, and the user has to manually setup TS in the test app.

To Do

- [x] we need https://github.com/ember-cli/ember-cli/pull/10048
- [x] add tests
