### PR TITLE
Fix test-app to not fail prettier linting

### DIFF
--- a/files/test-app-overrides/ember-cli-build.js
+++ b/files/test-app-overrides/ember-cli-build.js
@@ -5,8 +5,8 @@ const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 module.exports = function (defaults) {
   let app = new EmberApp(defaults, {
     autoImport: {
-      watchDependencies: ['<%= addonName %>']
-    }
+      watchDependencies: ['<%= addonName %>'],
+    },
   });
 
   const { maybeEmbroider } = require('@embroider/test-setup');


### PR DESCRIPTION
The changes added in #31 cause the test-app's linting to fail, due to prettier.