### PR TITLE
Support ember-cli-update

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,13 @@ use the `--release-it` flag
 ember addon my-addon -b @embroider/addon-blueprint --yarn --release-it
 ```
 
+### Updating the addon
+
+The blueprint supports `ember-cli-update` to update your addon with any changes that occurred in the blueprint since you created the addon. So to update your addons boilerplate, simply run `ember-cli-update` (or `npx ember-cli-update` if you haven't installed it globally). 
+
+For additional instructions, please consult its [documentation](https://github.com/ember-cli/ember-cli-update).
+
+
 ### In existing monorepos
 
 In existing monorepos, it may be helpful to establish a convention for generating v2 addons as sub-monorepos

--- a/files/config/ember-cli-update.json
+++ b/files/config/ember-cli-update.json
@@ -1,0 +1,16 @@
+{
+  "schemaVersion": "1.0.0",
+  "packages": [
+    {
+      "name": "@embroider/addon-blueprint",
+      "version": "<%= blueprintVersion %>",
+      "blueprints": [
+        {
+          "name": "@embroider/addon-blueprint",
+          "isBaseBlueprint": true,
+          "options": [<%= blueprintOptions %>]
+        }
+      ]
+    }
+  ]
+}

--- a/files/package.json
+++ b/files/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "<%= addonName %>",
   "version": "0.0.0",
   "private": true,
   "repository": "",

--- a/index.js
+++ b/index.js
@@ -11,6 +11,13 @@ const { merge } = require('lodash');
 
 let date = new Date();
 
+const ADDON_OPTIONS = [
+  'addonLocation',
+  'testAppLocation',
+  'testAppName',
+  'releaseIt',
+];
+
 const description = 'The default blueprint for Embroider v2 addons.';
 
 module.exports = {
@@ -112,6 +119,12 @@ module.exports = {
           options.welcome && '"--welcome"',
           options.yarn && '"--yarn"',
           options.ciProvider && `"--ci-provider=${options.ciProvider}"`,
+          options.addonLocation &&
+            `"--addon-location=${options.addonLocation}"`,
+          options.testAppLocation &&
+            `"--test-app-location=${options.testAppLocation}"`,
+          options.testAppName && `"--test-app-name=${options.testAppName}"`,
+          options.releaseIt && `"--release-it"`,
         ]
           .filter(Boolean)
           .join(',\n            ') +
@@ -123,7 +136,7 @@ module.exports = {
       testAppInfo,
       addonName: addonInfo.name.dashed,
       addonNamespace: addonInfo.name.classified,
-      // emberCLIVersion: require('../../package').version,
+      blueprintVersion: require('./package.json').version,
       year: date.getFullYear(),
       yarn: options.yarn,
       welcome: options.welcome,
@@ -178,8 +191,6 @@ function testAppInfoFromOptions(options) {
     location: options.testAppLocation || dashedName,
   };
 }
-
-const ADDON_OPTIONS = ['addonLocation', 'testAppLocation', 'releaseIt', 'testAppName'];
 
 function withoutAddonOptions(options) {
   let result = {};

--- a/index.js
+++ b/index.js
@@ -11,12 +11,7 @@ const { merge } = require('lodash');
 
 let date = new Date();
 
-const ADDON_OPTIONS = [
-  'addonLocation',
-  'testAppLocation',
-  'testAppName',
-  'releaseIt',
-];
+const ADDON_OPTIONS = ['addonLocation', 'testAppLocation', 'testAppName', 'releaseIt'];
 
 const description = 'The default blueprint for Embroider v2 addons.';
 
@@ -119,10 +114,8 @@ module.exports = {
           options.welcome && '"--welcome"',
           options.yarn && '"--yarn"',
           options.ciProvider && `"--ci-provider=${options.ciProvider}"`,
-          options.addonLocation &&
-            `"--addon-location=${options.addonLocation}"`,
-          options.testAppLocation &&
-            `"--test-app-location=${options.testAppLocation}"`,
+          options.addonLocation && `"--addon-location=${options.addonLocation}"`,
+          options.testAppLocation && `"--test-app-location=${options.testAppLocation}"`,
           options.testAppName && `"--test-app-name=${options.testAppName}"`,
           options.releaseIt && `"--release-it"`,
         ]


### PR DESCRIPTION
When more people are using this blueprint, while we are still iterating over it heavily, then keeping addons up to date with the blueprint will likely be very annoying. This should help, allowing all blueprint updates to be incorporated with a simple `ember-cli-update` call.