### PR TITLE
Fix test timeouts

### DIFF
--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -21,7 +21,11 @@ describe('ember addon <the addon> -b <this blueprint>', () => {
     args?: string[];
     options?: Options;
   }) {
-    let result = await execa('ember', ['addon', name, '-b', blueprintPath, ...args], options);
+    let result = await execa(
+      'ember',
+      ['addon', name, '-b', blueprintPath, '--skip-npm', '--skip-git', ...args],
+      options
+    );
 
     return { result, name };
   }

--- a/tests/vitest.config.ts
+++ b/tests/vitest.config.ts
@@ -4,7 +4,7 @@ const ONE_SECOND = 1_000;
 
 export default defineConfig({
   test: {
-    testTimeout: 30 * ONE_SECOND,
-    hookTimeout: 100 * ONE_SECOND,
+    testTimeout: 60 * ONE_SECOND,
+    hookTimeout: 150 * ONE_SECOND,
   },
 });


### PR DESCRIPTION
AFAICT the test installed the deps twice, once by default as part of running the blueprint, and later explicitly.

Also I was running into timeouts on my (meanwhile older) machine, should probably get one of those M*x* MBPs... 😬

~Unfortunately some diff noise here, due to prettier...~