### PR TITLE
Add Ember 4.4 LTS to addon blueprint, remove 3.24

### DIFF
--- a/files/.github/workflows/ci.yml
+++ b/files/.github/workflows/ci.yml
@@ -54,8 +54,8 @@ jobs:
       fail-fast: false
       matrix:
         try-scenario:
-          - ember-lts-3.24
           - ember-lts-3.28
+          - ember-lts-4.4
           - ember-release
           - ember-beta
           - ember-canary

--- a/files/README.md
+++ b/files/README.md
@@ -7,7 +7,7 @@
 Compatibility
 ------------------------------------------------------------------------------
 
-* Ember.js v3.24 or above
+* Ember.js v3.28 or above
 * Embroider or ember-auto-import v2
 
 

--- a/files/test-app-overrides/config/ember-try.js
+++ b/files/test-app-overrides/config/ember-try.js
@@ -8,18 +8,18 @@ module.exports = async function () {
     <% if (yarn) { %>useYarn: true,
     <% } %>scenarios: [
       {
-        name: 'ember-lts-3.24',
-        npm: {
-          devDependencies: {
-            'ember-source': '~3.24.3',
-          },
-        },
-      },
-      {
         name: 'ember-lts-3.28',
         npm: {
           devDependencies: {
             'ember-source': '~3.28.0',
+          },
+        },
+      },
+      {
+        name: 'ember-lts-4.4',
+        npm: {
+          devDependencies: {
+            'ember-source': '~4.4.0',
           },
         },
       },


### PR DESCRIPTION
Same as https://github.com/ember-cli/ember-cli/pull/9971