### PR TITLE
Use `prepack` rather than `prepublishOnly`

### DIFF
--- a/files/__addonLocation__/package.json
+++ b/files/__addonLocation__/package.json
@@ -22,7 +22,7 @@
     "lint:js:fix": "eslint . --fix",
     "start": "rollup --config --watch",
     "test": "echo 'A v2 addon does not have tests, run tests in test-app'",
-    "prepublishOnly": "rollup --config"
+    "prepack": "rollup --config"
   },
   "dependencies": {
     "@embroider/addon-shim": "^1.0.0"


### PR DESCRIPTION
The `prepublishOnly` script doesn't run when you execute `npm pack` (or the Yarn or pnpm equivalent), but you'd want Rollup to run before generating a tarball.

Historically, `ember-cli-typescript` encouraged the use of `prepublishOnly` for generating type declarations due to a bug in yarn, but that bug was resolved and we [switched to `prepack` there a couple of years ago](https://github.com/typed-ember/ember-cli-typescript/pull/1196).