### PR TITLE
Add --vitest flag

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,6 +51,19 @@ module.exports = {
       fs.unlink(path.join(testAppPath, '.travis.yml')),
     ];
 
+    if (options.vitest) {
+      tasks.push(
+        (async () => {
+          // lookupBlueprint (used above) does not lookup packages on npm
+          await execa(
+            'ember',
+            ['new', 'tests', '-b', 'vitest-blueprint', '--skip-git', '--skip-npm'],
+            { cwd: options.target }
+          );
+        })()
+      );
+    }
+
     if (options.releaseIt) {
       tasks.push(this.setupReleaseIt(options.target));
     }
@@ -113,6 +126,7 @@ module.exports = {
         [
           options.welcome && '"--welcome"',
           options.yarn && '"--yarn"',
+          options.vitest && '"--vitest"',
           options.ciProvider && `"--ci-provider=${options.ciProvider}"`,
           options.addonLocation && `"--addon-location=${options.addonLocation}"`,
           options.testAppLocation && `"--test-app-location=${options.testAppLocation}"`,
@@ -137,6 +151,7 @@ module.exports = {
       blueprintVersion: require('./package.json').version,
       year: date.getFullYear(),
       yarn: options.yarn,
+      vitest: options.vitest,
       welcome: options.welcome,
       blueprint: 'addon',
       blueprintOptions,


### PR DESCRIPTION
Uses https://github.com/NullVoxPopuli/vitest-blueprint

This is for projects where they don't need a test app or maybe have node things to test outside of the test app.

Ember historically hasn't made a decision on node-testing convention, but I think this is pretty easy (no other node testing tool comes close to the ease of use here (at least that's been released in 3+ months ago)).

For example, `@ember/string`'s [v2-addon-conversion PR](https://github.com/emberjs/ember-string/pull/345) the ember app has been fully removed in favor of node-only tests (which vitest is good at (minimal config, works with ESM and TS out of the box))).
This is because the addon is really just a utility library with some functions and doesn't do _anything_ ember-specific.
So v2 addons become a blueprint for rollup libraries, and not anything just ember specific.
