### PR TITLE
Fix packageName  wrong `start:tests` and `test`

### DIFF
--- a/src/root-package-json.js
+++ b/src/root-package-json.js
@@ -45,8 +45,10 @@ let scripts = {
    * @param {Info} info
    */
   npm: (options, info) => {
-    let { packageName: addonName } = info.addon;
-    let { packageName: testAppName } = info.addon;
+    let {
+      addon: { packageName: addonName },
+      testApp: { packageName: testAppName },
+    } = info;
 
     return {
       prepare: 'npm run build',
@@ -68,8 +70,10 @@ let scripts = {
    * @param {Info} info
    */
   yarn: (options, info) => {
-    let { packageName: addonName } = info.addon;
-    let { packageName: testAppName } = info.addon;
+    let {
+      addon: { packageName: addonName },
+      testApp: { packageName: testAppName },
+    } = info;
 
     return {
       prepare: `yarn build`,
@@ -91,8 +95,10 @@ let scripts = {
    * @param {Info} info
    */
   pnpm: (options, info) => {
-    let { packageName: addonName } = info.addon;
-    let { packageName: testAppName } = info.addon;
+    let {
+      addon: { packageName: addonName },
+      testApp: { packageName: testAppName },
+    } = info;
 
     return {
       /**


### PR DESCRIPTION
The way `root-package-json.js` sets up the scripts-section in `package.json` is incorrect for all package managers. This PR addresses this issue.

The issue was caused by us accessing `info.addon` for both the `addon`- and `testApp`-portions of the scripts, instead of using `testApp` for the section of the scripts that ought to run the scripts for the test application.

There is no test coverage for this functionality, so there was nothing for me to update, but I wonder if we want to add test coverage for what is in essence a template for the scripts portion of `package.json` 🤔 

Before, with wrong value for `start:tests` and `test`:
<img width="711" alt="Screenshot 2022-10-29 at 13 54 23" src="https://user-images.githubusercontent.com/242299/198830011-5fb65bb5-bed8-4b54-8b78-baeed0174056.png">

After:
<img width="696" alt="Screenshot 2022-10-29 at 13 53 27" src="https://user-images.githubusercontent.com/242299/198829990-28397483-7ee5-4f7b-9da1-54e0520e002b.png">


