### PR TITLE
Cleanup .eslintignore file in addon blueprint

### DIFF
--- a/files/__addonLocation__/.eslintignore
+++ b/files/__addonLocation__/.eslintignore
@@ -1,22 +1,8 @@
 # unconventional js
 /blueprints/*/files/
-/vendor/
 
 # compiled output
 /dist/
-/tmp/
-
-# dependencies
-/bower_components/
-/node_modules/
 
 # misc
 /coverage/
-!.*
-.*/
-.eslintcache
-
-# ember-try
-/.node_modules.ember-try/
-/bower.json.ember-try
-/package.json.ember-try


### PR DESCRIPTION
Follow up to https://github.com/embroider-build/addon-blueprint/pull/73