### PR TITLE
Update create-rwjblue-release-it-setup, adds support for `--release-it` and `--pnpm`

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "pnpm --filter 'blueprint-tests' test"
   },
   "dependencies": {
-    "create-rwjblue-release-it-setup": "^3.1.1",
+    "create-rwjblue-release-it-setup": "^4.0.0",
     "ember-cli-normalize-entity-name": "^1.0.0",
     "ember-cli-string-utils": "^1.1.0",
     "execa": "^5.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
       '@nullvoxpopuli/eslint-configs': ^2.2.35
       '@release-it-plugins/lerna-changelog': ^5.0.0
       '@typescript-eslint/parser': ^5.30.6
-      create-rwjblue-release-it-setup: ^3.1.1
+      create-rwjblue-release-it-setup: ^4.0.0
       ember-cli-normalize-entity-name: ^1.0.0
       ember-cli-string-utils: ^1.1.0
       eslint: ^8.19.0
@@ -24,7 +24,7 @@ importers:
       sort-package-json: ^1.54.0
       typescript: ^4.7.4
     dependencies:
-      create-rwjblue-release-it-setup: 3.1.1
+      create-rwjblue-release-it-setup: 4.0.0
       ember-cli-normalize-entity-name: 1.0.0
       ember-cli-string-utils: 1.1.0
       execa: 5.1.1
@@ -1388,12 +1388,12 @@ packages:
       yaml: 1.10.2
     dev: true
 
-  /create-rwjblue-release-it-setup/3.1.1:
-    resolution: {integrity: sha512-5glGVoybGwx0pt9tSUydBTcVo2Y5zfti0+PLkzASTFN0OKsc/l9MuQ7sZEqHGoVW2HUErGbqnfC8vhs/Vrmk5g==}
-    engines: {node: 10.* || 12.* || >= 14}
+  /create-rwjblue-release-it-setup/4.0.0:
+    resolution: {integrity: sha512-SN51FFk2GO4GWuVRuiwgk/V3DV+P86Rr/sdJssseXmmOfN/64YAn3L/7TiEJC/BhyAjXSpaSAcLmxWAK9LdmIw==}
+    engines: {node: 14.* || 16.* || >= 18}
     hasBin: true
     dependencies:
-      execa: 4.1.0
+      execa: 5.1.1
       gitconfiglocal: 2.1.0
       github-label-sync: 1.6.0
       hosted-git-info: 3.0.8
@@ -1664,12 +1664,6 @@ packages:
       iconv-lite: 0.6.3
     dev: true
     optional: true
-
-  /end-of-stream/1.4.4:
-    resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
-    dependencies:
-      once: 1.4.0
-    dev: false
 
   /enquirer/2.3.6:
     resolution: {integrity: sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==}
@@ -2375,21 +2369,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /execa/4.1.0:
-    resolution: {integrity: sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==}
-    engines: {node: '>=10'}
-    dependencies:
-      cross-spawn: 7.0.3
-      get-stream: 5.2.0
-      human-signals: 1.1.1
-      is-stream: 2.0.1
-      merge-stream: 2.0.0
-      npm-run-path: 4.0.1
-      onetime: 5.1.2
-      signal-exit: 3.0.7
-      strip-final-newline: 2.0.0
-    dev: false
-
   /execa/5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
@@ -2653,13 +2632,6 @@ packages:
   /get-stream/3.0.0:
     resolution: {integrity: sha512-GlhdIUuVakc8SJ6kK0zAFbiGzRFzNnY4jUuEbV9UROo4Y+0Ny4fjvcZFVTeDA4odpFyOQzaw6hXukJSq/f28sQ==}
     engines: {node: '>=4'}
-    dev: false
-
-  /get-stream/5.2.0:
-    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
-    engines: {node: '>=8'}
-    dependencies:
-      pump: 3.0.0
     dev: false
 
   /get-stream/6.0.1:
@@ -3000,11 +2972,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
-
-  /human-signals/1.1.1:
-    resolution: {integrity: sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==}
-    engines: {node: '>=8.12.0'}
-    dev: false
 
   /human-signals/2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
@@ -4623,13 +4590,6 @@ packages:
     resolution: {integrity: sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==}
     dev: false
 
-  /pump/3.0.0:
-    resolution: {integrity: sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==}
-    dependencies:
-      end-of-stream: 1.4.4
-      once: 1.4.0
-    dev: false
-
   /punycode/2.1.1:
     resolution: {integrity: sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==}
     engines: {node: '>=6'}
@@ -5572,7 +5532,7 @@ packages:
     dev: true
 
   /verror/1.10.0:
-    resolution: {integrity: sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=}
+    resolution: {integrity: sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==}
     engines: {'0': node >=0.6.0}
     dependencies:
       assert-plus: 1.0.0


### PR DESCRIPTION
Fixes #70, see https://github.com/rwjblue/create-rwjblue-release-it-setup/releases/tag/v4.0.0