### PR TITLE
Add missing peerDependencies

### DIFF
--- a/files/__addonLocation__/package.json
+++ b/files/__addonLocation__/package.json
@@ -37,6 +37,7 @@
     "@embroider/addon-dev": "^2.0.0",<% if (typescript) { %>
     "@glint/core": "^0.9.7",
     "@glint/environment-ember-loose": "^0.9.7",
+    "@glimmer/component": "^1.1.2",
     "@tsconfig/ember": "^1.0.0",
     "@types/ember": "^4.0.0",
     "@types/ember__object": "^4.0.0",
@@ -58,8 +59,10 @@
     "@types/ember__test-helpers": "^2.6.1",
     "@typescript-eslint/eslint-plugin": "^5.30.5",
     "@typescript-eslint/parser": "^5.30.5",<% } else { %>
+    "@glimmer/component": "^1.1.2",
     "@rollup/plugin-babel": "^5.3.0",<% } %>
     "concurrently": "^7.2.1",
+    "ember-cli-htmlbars": "^6.1.1",
     "ember-template-lint": "^4.0.0",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.3.0",

--- a/index.js
+++ b/index.js
@@ -99,6 +99,7 @@ module.exports = {
     merge(pkg, additions);
 
     // we must explicitly add our own v2 addon here, the implicit magic of the legacy dummy app does not work
+    pkg.devDependencies['@babel/core'] = '^7.17.0';
     pkg.devDependencies[this.locals(this.options).addonName] = '^0.0.0';
 
     return fs.writeFile(packageJsonPath, JSON.stringify(sortPackageJson(pkg), undefined, 2));


### PR DESCRIPTION
Running commands:

```sh
ember addon my-addon -b @embroider/addon-blueprint --pnpm --skip-npm --release-it --typescript
cd my-addon
ppm install
```

got following errors:

```
 WARN  Issues with peer dependencies found
my-addon
├─┬ @glint/environment-ember-loose 0.9.7
│ ├── ✕ missing peer @glimmer/component@^1.1.2
│ ├── ✕ missing peer ember-cli-htmlbars@^6.0.1
│ └─┬ @glint/template 0.9.7
│   └── ✕ missing peer @glimmer/component@^1.1.2
└─┬ ember-template-lint 4.18.1
  └─┬ ember-template-imports 3.4.0
    └── ✕ missing peer ember-cli-htmlbars@^6.0.0
Peer dependencies that should be installed:
  @glimmer/component@">=1.1.2 <2.0.0"  ember-cli-htmlbars@">=6.0.1 <7.0.0"  

test-app
├─┬ @ember/test-helpers 2.8.1
│ └─┬ ember-destroyable-polyfill 2.0.3
│   └─┬ ember-compatibility-helpers 1.2.6
│     └─┬ babel-plugin-debug-macros 0.2.0
│       └── ✕ missing peer @babel/core@^7.0.0-beta.42
├─┬ @glimmer/component 1.1.2
│ └─┬ ember-cli-typescript 3.0.0
│   └─┬ @babel/plugin-transform-typescript 7.5.5
│     ├── ✕ missing peer @babel/core@^7.0.0-0
│     ├─┬ @babel/helper-create-class-features-plugin 7.20.2
│     │ └── ✕ missing peer @babel/core@^7.0.0
│     └─┬ @babel/plugin-syntax-typescript 7.20.0
│       └── ✕ missing peer @babel/core@^7.0.0-0
├─┬ ember-data 4.3.0
│ └─┬ @ember-data/adapter 4.3.0
│   └─┬ @ember-data/private-build-infra 4.3.0
│     ├─┬ @babel/plugin-transform-block-scoping 7.20.2
│     │ └── ✕ missing peer @babel/core@^7.0.0-0
│     └─┬ babel-plugin-debug-macros 0.3.4
│       └── ✕ missing peer @babel/core@^7.0.0
└─┬ ember-load-initializers 2.1.2
  └─┬ ember-cli-typescript 2.0.2
    ├─┬ @babel/plugin-proposal-class-properties 7.18.6
    │ └── ✕ missing peer @babel/core@^7.0.0-0
    └─┬ @babel/plugin-transform-typescript 7.4.5
      └── ✕ missing peer @babel/core@^7.0.0-0
Peer dependencies that should be installed:
  @babel/core@">=7.0.0 <8.0.0"
```

this PR adds those missing peer dependencies to both addon and test-app