### PR TITLE
Fix accidental resolutions

### DIFF
--- a/files/__addonLocation__/rollup.config.__rollupExt__
+++ b/files/__addonLocation__/rollup.config.__rollupExt__
@@ -22,6 +22,11 @@ export default {
     // not everything in publicEntrypoints necessarily needs to go here.
     addon.appReexports(['components/**/*.js']),
 
+    // Follow the V2 Addon rules about dependencies. Your code can import from
+    // `dependencies` and `peerDependencies` as well as standard Ember-provided
+    // package names.
+    addon.dependencies(),
+
 <% if (typescript) { %>    // compile TypeScript to latest JavaScript, including Babel transpilation
     typescript({
       transpiler: 'babel',
@@ -38,11 +43,6 @@ export default {
       babelHelpers: 'bundled',
     }),
 <% } %>
-    // Follow the V2 Addon rules about dependencies. Your code can import from
-    // `dependencies` and `peerDependencies` as well as standard Ember-provided
-    // package names.
-    addon.dependencies(),
-
     // Ensure that standalone .hbs files are properly integrated as Javascript.
     addon.hbs(),
 


### PR DESCRIPTION
The `addon.dependencies()` plugin is supposed to ensure that ember-specific imports are left alone during the addon build. For example, it will mark `@embroider/macros` as external so that rollup won't try to inline it, since that would be incorrect.

But the rollup typescript plugin *also* does its own resolution step, and if it happens to locate a matching module that will preempt `addon.dependencies()`.

In the case of `@embroider/macros` this can result in runtime errors like
> this method is really implemented at compile time via a babel plugin. If you're seeing this exception, something went wrong

The fix is to reorder the plugins.