### PR TITLE
Bump `@embroider/addon-dev`

### DIFF
--- a/files/__addonLocation__/package.json
+++ b/files/__addonLocation__/package.json
@@ -34,7 +34,7 @@
     "@babel/plugin-proposal-class-properties": "^7.16.7",
     "@babel/plugin-proposal-decorators": "^7.17.0",
     "@babel/plugin-syntax-decorators": "^7.17.0",
-    "@embroider/addon-dev": "^2.0.0",<% if (typescript) { %>
+    "@embroider/addon-dev": "^3.0.0",<% if (typescript) { %>
     "@glint/core": "^0.9.7",
     "@glint/environment-ember-loose": "^0.9.7",
     "@tsconfig/ember": "^1.0.0",


### PR DESCRIPTION
Closes #81

We didn't use `@embroider/addon-dev/template-transform-plugin` in the default blueprint before, so the breaking changes don't affect us here, right? @ef4 