### PR TITLE
Use latest `ember-cli` beta version in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/pnpm
-      - run: pnpm add --global ember-cli yarn
+      # use ember-cli 4.10.0 beta, as this version is the first to support --typescript properly. @todo Revert this when 4.10.0 is stable      
+      - run: pnpm add --global ember-cli@beta yarn
       - run: pnpm vitest --testNamePattern "${{ matrix.slow-test }}"
         working-directory: tests


### PR DESCRIPTION
CI currently fails the typescript tests, due to a known issue (https://github.com/embroider-build/addon-blueprint/issues/82) that the latest stable version (4.9.x) of ember-cli support `--typescript`, but a fix when generating the app in a custom directory (https://github.com/ember-cli/ember-cli/pull/10048) is only released for the 4.10.0-beta version. Se we use the latter in CI.