### PR TITLE
Don't fail-fast in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
     timeout-minutes: 5
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         # how to say "not these" so we don't miss anything?
         # waiting on a an api from vitest for querying


### PR DESCRIPTION
Let all matrix jobs run, regardless of other failures