### PR TITLE
Update broken test-app script overrides

### DIFF
--- a/additional-test-app-package.json
+++ b/additional-test-app-package.json
@@ -4,9 +4,5 @@
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-try": "^2.0.0",
     "ember-source-channel-url": "^3.0.0"
-  },
-  "scripts": {
-    "test:watch": "ember test --server",
-    "test": "npm-run-all lint \"test:!(watch)\""
   }
 }


### PR DESCRIPTION
The default app blueprint has migrated away from `npm-run-all` to `concurrently`, but we had this override still in place, which now refers to a missing dependency. The main reason we had the override was the `test:watch` script, which we might actually not need really? (it forces us to exclude it from `test`, so makes our override very brittle)