### PR TITLE
Update babel config to allow declare fields. I first tried this with …

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,14 +48,13 @@ jobs:
           - defaults with pnpm
           - addon-location
           - test-app-location
-          # skip TS tests until EmberCLI 4.10.0 is released, see https://github.com/embroider-build/addon-blueprint/issues/82
-          # - typescript
+          - typescript
           - monorepo with npm
           - monorepo with yarn
           - monorepo with pnpm
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/pnpm
-      - run: pnpm add --global ember-cli yarn
+      - run: pnpm add --global ember-cli@4.10.0-beta.0 yarn
       - run: pnpm vitest --testNamePattern "${{ matrix.slow-test }}"
         working-directory: tests

--- a/files/__addonLocation__/babel.config.json
+++ b/files/__addonLocation__/babel.config.json
@@ -2,7 +2,8 @@
 <% if (typescript) { %>  "presets": [["@babel/preset-typescript", { "allowDeclareFields": true }]],
 <% } %>  "plugins": [
     "@embroider/addon-dev/template-colocation-plugin",
-    ["@babel/plugin-proposal-decorators", { "legacy": true }],
+    <%if (typescript ){ %>["@babel/plugin-transform-typescript", { "allowDeclareFields": true }],
+    <% } %>["@babel/plugin-proposal-decorators", { "legacy": true }],
     "@babel/plugin-proposal-class-properties"
   ]
 }

--- a/files/__addonLocation__/babel.config.json
+++ b/files/__addonLocation__/babel.config.json
@@ -1,5 +1,5 @@
 {
-<% if (typescript) { %>  "presets": [["@babel/preset-typescript"]],
+<% if (typescript) { %>  "presets": [["@babel/preset-typescript", { "allowDeclareFields": true }]],
 <% } %>  "plugins": [
     "@embroider/addon-dev/template-colocation-plugin",
     ["@babel/plugin-proposal-decorators", { "legacy": true }],

--- a/files/__addonLocation__/package.json
+++ b/files/__addonLocation__/package.json
@@ -56,7 +56,6 @@
     "@types/ember__error": "^4.0.0",
     "@types/ember__component": "^4.0.0",
     "@types/ember__routing": "^4.0.0",
-    "@types/ember__test-helpers": "^2.9.1",
     "@typescript-eslint/eslint-plugin": "^5.30.5",
     "@typescript-eslint/parser": "^5.30.5",<% } else { %>
     "@rollup/plugin-babel": "^5.3.0",<% } %>

--- a/files/__addonLocation__/package.json
+++ b/files/__addonLocation__/package.json
@@ -30,7 +30,8 @@
   },
   "devDependencies": {
     "@babel/core": "^7.17.0",
-    <% if (typescript) { %>"@babel/preset-typescript": "^7.18.6"<% } else { %>"@babel/eslint-parser": "^7.18.2"<% } %>,
+    <% if (typescript) { %>"@babel/preset-typescript": "^7.18.6",
+    "@babel/plugin-transform-typescript": "^7.17.0"<% } else { %>"@babel/eslint-parser": "^7.18.2"<% } %>,
     "@babel/plugin-proposal-class-properties": "^7.16.7",
     "@babel/plugin-proposal-decorators": "^7.17.0",
     "@babel/plugin-syntax-decorators": "^7.17.0",

--- a/files/__addonLocation__/package.json
+++ b/files/__addonLocation__/package.json
@@ -20,7 +20,7 @@
     "lint:js": "eslint . --cache",
     "lint:hbs:fix": "ember-template-lint . --fix --no-error-on-unmatched-pattern",
     "lint:js:fix": "eslint . --fix",<% if (typescript) { %>
-    "lint:types": "glint",<% } %>
+    "lint:types": "glint --build",<% } %>
     "start": "rollup --config --watch",
     "test": "echo 'A v2 addon does not have tests, run tests in test-app'",
     "prepack": "rollup --config"
@@ -56,6 +56,7 @@
     "@types/ember__error": "^4.0.0",
     "@types/ember__component": "^4.0.0",
     "@types/ember__routing": "^4.0.0",
+    "@types/ember__test-helpers": "^2.9.1",
     "@typescript-eslint/eslint-plugin": "^5.30.5",
     "@typescript-eslint/parser": "^5.30.5",<% } else { %>
     "@rollup/plugin-babel": "^5.3.0",<% } %>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,7 +47,7 @@ importers:
       '@types/fs-extra': ^9.0.13
       '@vitest/ui': ^0.18.0
       c8: ^7.11.3
-      ember-cli: ^4.9.2
+      ember-cli: ^4.10.0-beta.0
       execa: ^6.1.0
       fixturify: ^3.0.0
       fs-extra: ^10.0.0
@@ -58,7 +58,7 @@ importers:
       '@types/fs-extra': 9.0.13
       '@vitest/ui': 0.18.0
       c8: 7.11.3
-      ember-cli: 4.9.2
+      ember-cli: 4.10.0-beta.0
       execa: 6.1.0
       fixturify: 3.0.0
       fs-extra: 10.1.0
@@ -3302,8 +3302,8 @@ packages:
   /ember-cli-string-utils/1.1.0:
     resolution: {integrity: sha512-PlJt4fUDyBrC/0X+4cOpaGCiMawaaB//qD85AXmDRikxhxVzfVdpuoec02HSiTGTTB85qCIzWBIh8lDOiMyyFg==}
 
-  /ember-cli/4.9.2:
-    resolution: {integrity: sha512-zvZjB0uHY2ewCrfNc0k3dM9QpfcDQ4GW5h1MmNXN7+nAPfFROSwJ/o24t6DHUFcU/B9H7Dd+2GGC4W6NKz6Shw==}
+  /ember-cli/4.10.0-beta.0:
+    resolution: {integrity: sha512-g9wa7LfiYuKd044axju2wD2/thKRL//jVfPccA/zhxw1V0rl7OWSpUMBg7ck0s5b3I0v75TL8I+QvJxHg5emtw==}
     engines: {node: '>= 14'}
     hasBin: true
     dependencies:

--- a/src/root-package-json.js
+++ b/src/root-package-json.js
@@ -76,7 +76,9 @@ let scripts = {
     } = info;
 
     return {
-      prepare: `yarn build`,
+      // Have to disable, because ember-cli does not allow `yarn` to *not* run when using --skip-npm
+      // This breaks builds using other package managers
+      // prepare: `yarn build`,
       build: `yarn workspace ${addonName} run build`,
 
       start: `concurrently 'npm:start:*' --restart-after 5000 --prefix-colors cyan,white,yellow`,
@@ -101,12 +103,14 @@ let scripts = {
     } = info;
 
     return {
+      // Have to disable, because ember-cli does not allow `yarn` to *not* run when using --skip-npm
+      // This breaks builds using other package managers
       /**
        * For most optimized C.I., this will likely want to be removed, but
        * the prepare scripts helps folks get going quicker without having to understand
        * that every step in C.I. that needs the addon also needs the addon to be built first.
        */
-      prepare: `pnpm build`,
+      // prepare: `pnpm build`,
       build: `pnpm --filter ${addonName} build`,
       /**
        * restart-after exists because ember-cli continually crashes

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -144,13 +144,10 @@ describe('ember addon <the addon> -b <this blueprint>', () => {
     beforeAll(async () => {
       tmpDir = await createTmp();
 
-      /**
-       * NOTE: we have to use either yarn or npm, because ember-cli doesn't support anything else.
-       *       (this is encountered during the app's --typescript phase when it uses --yarn to install
-       *       the deps of ember-cli-typescript)
-       */
+      // Using pnpm, because:
+      // https://github.com/typed-ember/glint/pull/516
       let { name } = await createAddon({
-        args: ['--typescript', '--yarn=true'],
+        args: ['--typescript', '--pnpm=true', '--skip-npm'],
         options: { cwd: tmpDir },
       });
 
@@ -163,15 +160,10 @@ describe('ember addon <the addon> -b <this blueprint>', () => {
        * Also pnpm is better for the environment.
        */
       try {
-        await install({ cwd, packageManager: 'yarn' });
+        await install({ cwd, packageManager: 'pnpm' });
       } catch {
         // :shrug:
       }
-
-      // https://github.com/typed-ember/glint/pull/516
-      await execa('yarn', ['add', '--dev', '@types/ember__test-helpers'], {
-        cwd: addonDir,
-      });
 
       /**
        * A common feature used in TS code-bases is the `declare` field augment.

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -139,6 +139,7 @@ describe('ember addon <the addon> -b <this blueprint>', () => {
     let cwd = '';
     let tmpDir = '';
     let distDir = '';
+    let addonDir = '';
 
     beforeAll(async () => {
       tmpDir = await createTmp();
@@ -149,6 +150,7 @@ describe('ember addon <the addon> -b <this blueprint>', () => {
       });
 
       cwd = path.join(tmpDir, name);
+      addonDir = path.join(cwd, name);
       distDir = path.join(cwd, name, 'dist');
 
       /**
@@ -162,7 +164,9 @@ describe('ember addon <the addon> -b <this blueprint>', () => {
       }
 
       // https://github.com/typed-ember/glint/pull/516
-      await execa('pnpm', ['add', '--save-dev', '@types/ember__test-helpers'], { cwd });
+      await execa('pnpm', ['add', '--save-dev', '@types/ember__test-helpers'], {
+        cwd: addonDir,
+      });
 
       /**
        * A common feature used in TS code-bases is the `declare` field augment.
@@ -178,15 +182,13 @@ describe('ember addon <the addon> -b <this blueprint>', () => {
        */
 
       await fs.writeFile(
-        path.join(cwd, 'src/index.js'),
-        `
-         import { service } from '@ember/service';
-         import type RouterService from '@ember/routing/service';
-
-         export class Example {
-           @service declare router: RouterService;
-         }
-       `
+        path.join(addonDir, 'src/index.ts'),
+        `import { service } from '@ember/service';\n` +
+          `import type RouterService from '@ember/routing/router-service';\n` +
+          `\n` +
+          `export class Example {\n` +
+          `  @service declare router: RouterService;\n` +
+          `}\n`
       );
     });
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -144,8 +144,13 @@ describe('ember addon <the addon> -b <this blueprint>', () => {
     beforeAll(async () => {
       tmpDir = await createTmp();
 
+      /**
+       * NOTE: we have to use either yarn or npm, because ember-cli doesn't support anything else.
+       *       (this is encountered during the app's --typescript phase when it uses --yarn to install
+       *       the deps of ember-cli-typescript)
+       */
       let { name } = await createAddon({
-        args: ['--typescript', '--pnpm=true'],
+        args: ['--typescript', '--yarn=true'],
         options: { cwd: tmpDir },
       });
 
@@ -158,13 +163,13 @@ describe('ember addon <the addon> -b <this blueprint>', () => {
        * Also pnpm is better for the environment.
        */
       try {
-        await install({ cwd, packageManager: 'pnpm' });
+        await install({ cwd, packageManager: 'yarn' });
       } catch {
         // :shrug:
       }
 
       // https://github.com/typed-ember/glint/pull/516
-      await execa('pnpm', ['add', '--save-dev', '@types/ember__test-helpers'], {
+      await execa('yarn', ['add', '--dev', '@types/ember__test-helpers'], {
         cwd: addonDir,
       });
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -155,7 +155,14 @@ describe('ember addon <the addon> -b <this blueprint>', () => {
        * We should _strongly_ recommend against using `--yarn` because Yarn@v1 is objectively bad.
        * Also pnpm is better for the environment.
        */
-      await install({ cwd, packageManager: 'pnpm' });
+      try {
+        await install({ cwd, packageManager: 'pnpm' });
+      } catch {
+        // :shrug:
+      }
+
+      // https://github.com/typed-ember/glint/pull/516
+      await execa('pnpm', ['add', '--save-dev', '@types/ember__test-helpers'], { cwd });
 
       /**
        * A common feature used in TS code-bases is the `declare` field augment.

--- a/tests/package.json
+++ b/tests/package.json
@@ -9,7 +9,7 @@
     "@types/fs-extra": "^9.0.13",
     "@vitest/ui": "^0.18.0",
     "c8": "^7.11.3",
-    "ember-cli": "^4.9.2",
+    "ember-cli": "^4.10.0-beta.0",
     "execa": "^6.1.0",
     "fixturify": "^3.0.0",
     "fs-extra": "^10.0.0",

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -18,6 +18,32 @@ export async function createTmp() {
 export async function install({ cwd, packageManager }: { cwd: string; packageManager: string }) {
   if (packageManager === 'yarn') {
     await execa('yarn', ['install', '--non-interactive'], { cwd });
+  } else if (packageManager === 'npm') {
+    //  --force is used because:
+    //
+    //  ERESOLVE unable to resolve dependency tree
+    //
+    //  While resolving: test-app@0.0.0
+    //  Found: ember-cli@4.10.0-beta.0
+    //  node_modules/ember-cli
+    //    dev ember-cli@\"~4.10.0-beta.0\" from test-app@0.0.0
+    //    test-app
+    //      test-app@0.0.0
+    //      node_modules/test-app
+    //        workspace test-app from the root project
+    //
+    //  Could not resolve dependency:
+    //  peer ember-cli@\"^3.2.0 || ^4.0.0\" from ember-cli-dependency-checker@3.3.1
+    //  node_modules/ember-cli-dependency-checker
+    //    dev ember-cli-dependency-checker@\"^3.3.1\" from test-app@0.0.0
+    //    test-app
+    //      test-app@0.0.0
+    //      node_modules/test-app
+    //        workspace test-app from the root project
+    //
+    //  Fix the upstream dependency conflict, or retry
+    //  this command with --force, or --legacy-peer-deps
+    await execa('npm', ['install', '--force'], { cwd });
   } else {
     try {
       await execa(packageManager, ['install'], { cwd });


### PR DESCRIPTION
…just the preset options, but those had no affect on transpilation.
(likely because rollup-plugin-ts is messing with the `preset`?)

I'm testing the v2-addon output here: https://github.com/NullVoxPopuli/repro-v2-addon-ts-test-helpers-issue
(but just the addon part (not the test app), as it's the addon's type checking that's been goofy)
