### PR TITLE
Split monorepo tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,9 @@ jobs:
           - test-app-location
           # skip TS tests until EmberCLI 4.10.0 is released, see https://github.com/embroider-build/addon-blueprint/issues/82
           # - typescript
-          - existing monorepo
+          - monorepo with npm
+          - monorepo with yarn
+          - monorepo with pnpm
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/pnpm

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -281,7 +281,7 @@ describe('ember addon <the addon> -b <this blueprint>', () => {
     };
 
     ['npm', 'yarn', 'pnpm'].map((packageManager) =>
-      describe(`with ${packageManager}`, () => {
+      describe(`monorepo with ${packageManager}`, () => {
         let cwd = '';
         let tmpDir = '';
         let addonLocation = 'my-addon';


### PR DESCRIPTION
Similar to default tests, to run slow package installs in parallel.