### PR TITLE
Fix files that get copied from root to addon

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,8 @@ async function createTmp() {
   return tmpDirPath;
 }
 
-const filesToCopyFromRootToAddon = ['README.md', 'CONTRIBUTING.md'];
+const filesToCopyFromRootToAddonDuringBuild = ['README.md', 'LICENSE.md'];
+const filesToCopyFromRootToAddonInExistingMonorepo = ['README.md', 'CONTRIBUTING.md'];
 
 module.exports = {
   description,
@@ -101,7 +102,7 @@ module.exports = {
     await fs.move(originalAddonDir, tmpAddonDir);
     await fs.move(originalTestAppDir, tmpTestAppDir);
 
-    for (let fileToCopy of filesToCopyFromRootToAddon) {
+    for (let fileToCopy of filesToCopyFromRootToAddonInExistingMonorepo) {
       await fs.move(fileToCopy, path.join(tmpAddonDir, fileToCopy));
     }
 
@@ -248,7 +249,7 @@ module.exports = {
       blueprintOptions,
       ciProvider: options.ciProvider,
       pathFromAddonToRoot,
-      filesToCopyFromRootToAddon,
+      filesToCopyFromRootToAddon: filesToCopyFromRootToAddonDuringBuild,
       isExistingMonorepo: this.isExistingMonorepo,
     };
   },

--- a/tests/assertions.ts
+++ b/tests/assertions.ts
@@ -10,6 +10,7 @@ interface AssertGeneratedOptions {
   addonName?: string;
   testAppLocation?: string;
   testAppName?: string;
+  expectedStaticFiles?: string[];
 }
 
 /**
@@ -22,6 +23,7 @@ export async function assertGeneratedCorrectly({
   addonName = 'my-addon',
   testAppLocation = 'test-app',
   testAppName = 'test-app',
+  expectedStaticFiles = ['README.md', 'LICENSE.md'],
 }: AssertGeneratedOptions) {
   let addonPath = path.join(projectRoot, addonLocation);
   let testAppPath = path.join(projectRoot, testAppLocation);
@@ -42,8 +44,6 @@ export async function assertGeneratedCorrectly({
     ],
     `The test app has a (dev)dependency on the addon`
   ).to.include(addonName);
-
-  let expectedStaticFiles = ['README.md', 'CONTRIBUTING.md'];
 
   for (let expectedFile of expectedStaticFiles) {
     let pathToFile = path.join(addonPath, expectedFile);

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -358,7 +358,10 @@ describe('ember addon <the addon> -b <this blueprint>', () => {
         });
 
         it('was generated correctly', async () => {
-          await assertGeneratedCorrectly({ projectRoot: cwd });
+          await assertGeneratedCorrectly({
+            projectRoot: cwd,
+            expectedStaticFiles: ['README.md', 'CONTRIBUTING.md'],
+          });
         });
 
         it('runs tests', async () => {
@@ -446,7 +449,12 @@ describe('ember addon <the addon> -b <this blueprint>', () => {
       });
 
       it('was generated correctly', async () => {
-        assertGeneratedCorrectly({ projectRoot: cwd, addonLocation, testAppLocation });
+        assertGeneratedCorrectly({
+          projectRoot: cwd,
+          addonLocation,
+          testAppLocation,
+          expectedStaticFiles: ['README.md', 'CONTRIBUTING.md'],
+        });
       });
 
       it('runs tests', async () => {


### PR DESCRIPTION
#88 tried to be smart, by applying the same copy-files-from-root-to-addon logic both for "regular" addons (where this happens in the rollup build) _and_ for addons within an existing monorepo (where this happens at initial generation time). 

But it turned out this was actually wrong:
* we need to copy `README.md` in both cases
* we need to copy `LICENSE.md` only for regular addons (assuming addons in existing monorepos likely have no license as they are internal/private)
* we need to copy `CONTRIBUTING.md` only for addons in existing monorepos (as that file is likely not expected to be at the root level for the whole repo)