### PR TITLE
Remove deprecated `@types/ember__test-helpers`

### DIFF
--- a/files/__addonLocation__/package.json
+++ b/files/__addonLocation__/package.json
@@ -55,7 +55,6 @@
     "@types/ember__error": "^4.0.0",
     "@types/ember__component": "^4.0.0",
     "@types/ember__routing": "^4.0.0",
-    "@types/ember__test-helpers": "^2.6.1",
     "@typescript-eslint/eslint-plugin": "^5.30.5",
     "@typescript-eslint/parser": "^5.30.5",<% } else { %>
     "@rollup/plugin-babel": "^5.3.0",<% } %>


### PR DESCRIPTION
The type package has been deprecated and is basically a no-op package now, with types coming directly from `@ember/test-helpers`, so can be removed here. Also, the v2 addon doesn't have tests, so that dependency probably should have never existed!?

We cannot remove it from the test-app, as that is generated by e-c-ts, for which there is this PR: https://github.com/typed-ember/ember-cli-typescript/pull/1545

Although I think the intention for this package was to peacefully sit there and do nothing, somehow it was causing build failures for v2 addons it seems (see [this CI run](https://github.com/CrowdStrike/ember-headless-form/actions/runs/3901941999/jobs/6664395134#step:5:47)), maybe related to the use of `rollup-plugin-ts`? 🤔 

```
. prepare: [!] (plugin Typescript) TS2688: Cannot find type definition file for 'ember__test-helpers'.
. prepare:   The file is in the program because:
. prepare:     Entry point for implicit type library 'ember__test-helpers'
```

/cc @chriskrycho @dfreeman @jamescdavis