### PR TITLE
Need to use glint --build

### DIFF
--- a/files/__addonLocation__/package.json
+++ b/files/__addonLocation__/package.json
@@ -20,7 +20,7 @@
     "lint:js": "eslint . --cache",
     "lint:hbs:fix": "ember-template-lint . --fix --no-error-on-unmatched-pattern",
     "lint:js:fix": "eslint . --fix",<% if (typescript) { %>
-    "lint:types": "glint",<% } %>
+    "lint:types": "glint --build",<% } %>
     "start": "rollup --config --watch",
     "test": "echo 'A v2 addon does not have tests, run tests in test-app'",
     "prepack": "rollup --config"


### PR DESCRIPTION
Noticed this while working on https://github.com/embroider-build/addon-blueprint/pull/89

rollup (using tsc?), reported:
```
error TS2688: Cannot find type definition file for 'ember__test-helpers'.
  The file is in the program because:
    Entry point for implicit type library 'ember__test-helpers'
```
but `lint:types` was not.

to make `glint` behave in the same way, I changed `lint:types` to do `glint --build`, which now behaves the same as `tsc`.

    
cc @dfreeman @chriskrycho @simonihmig 