### PR TITLE
Resolve peers from Glint and/or ember-source

### DIFF
--- a/files/__addonLocation__/package.json
+++ b/files/__addonLocation__/package.json
@@ -27,7 +27,7 @@
   },
   "peerDependencies": {
     "@glimmer/component": "^1.1.2",
-    "ember-source": "^4.0.0",
+    "ember-source": "^4.0.0"
   },
   "dependencies": {
     "@embroider/addon-shim": "^1.0.0"

--- a/files/__addonLocation__/package.json
+++ b/files/__addonLocation__/package.json
@@ -26,7 +26,6 @@
     "prepack": "rollup --config"
   },
   "peerDependencies": {
-    "@glimmer/component": "^1.1.2",
     "ember-source": "^4.0.0"
   },
   "dependencies": {

--- a/files/__addonLocation__/package.json
+++ b/files/__addonLocation__/package.json
@@ -38,10 +38,10 @@
     "@babel/plugin-proposal-class-properties": "^7.16.7",
     "@babel/plugin-proposal-decorators": "^7.17.0",
     "@babel/plugin-syntax-decorators": "^7.17.0",
+    "@glimmer/component": "^1.1.2",
     "@embroider/addon-dev": "^3.0.0",<% if (typescript) { %>
     "@glint/core": "^0.9.7",
     "@glint/environment-ember-loose": "^0.9.7",
-    "@glimmer/component": "^1.1.2",
     "@tsconfig/ember": "^1.0.0",
     "@types/ember": "^4.0.0",
     "@types/ember__object": "^4.0.0",

--- a/files/__addonLocation__/package.json
+++ b/files/__addonLocation__/package.json
@@ -25,6 +25,10 @@
     "test": "echo 'A v2 addon does not have tests, run tests in test-app'",
     "prepack": "rollup --config"
   },
+  "peerDependencies": {
+    "@glimmer/component": "^1.1.2",
+    "ember-source": "^4.0.0",
+  },
   "dependencies": {
     "@embroider/addon-shim": "^1.0.0"
   },
@@ -37,6 +41,7 @@
     "@embroider/addon-dev": "^3.0.0",<% if (typescript) { %>
     "@glint/core": "^0.9.7",
     "@glint/environment-ember-loose": "^0.9.7",
+    "@glimmer/component": "^1.1.2",
     "@tsconfig/ember": "^1.0.0",
     "@types/ember": "^4.0.0",
     "@types/ember__object": "^4.0.0",
@@ -59,6 +64,7 @@
     "@typescript-eslint/parser": "^5.30.5",<% } else { %>
     "@rollup/plugin-babel": "^5.3.0",<% } %>
     "concurrently": "^7.2.1",
+    "ember-source": "^4.0.0",
     "ember-template-lint": "^4.0.0",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.3.0",


### PR DESCRIPTION
… (and ember-source would be required the moment you import anything anyway)

`@glimmer/component` is required by Glint
`ember-source` is required by nearly everything 🙃 (so this addition is more preemptive than anything)

Partially resolves #100 and #77