### PR TITLE
Alphabetized and standardized the root package.json scripts

### DIFF
--- a/src/root-package-json.js
+++ b/src/root-package-json.js
@@ -56,7 +56,7 @@ let scripts = {
       'lint:fix': 'npm run lint:fix --workspaces --if-present',
       prepare: 'npm run build',
       start: "concurrently 'npm:start:*' --restart-after 5000 --prefix-colors cyan,white,yellow",
-      'start:addon': `npm start --workspace ${addonName}`,
+      'start:addon': `npm start --workspace ${addonName} -- --no-watch.clearScreen`,
       'start:test-app': `npm start --workspace ${testAppName}`,
       test: 'npm run test --workspaces --if-present',
     };
@@ -113,7 +113,7 @@ let scripts = {
        * Colors are customizable
        */
       start: "concurrently 'npm:start:*' --restart-after 5000 --prefix-colors cyan,white,yellow",
-      'start:addon': `pnpm --filter ${addonName} start`,
+      'start:addon': `pnpm --filter ${addonName} start --no-watch.clearScreen`,
       'start:test-app': `pnpm --filter ${testAppName} start`,
       /**
        * Note that this test is different from v1 addon's test, which runs all of ember-try as well.

--- a/src/root-package-json.js
+++ b/src/root-package-json.js
@@ -57,7 +57,7 @@ let scripts = {
       prepare: 'npm run build',
       start: "concurrently 'npm:start:*' --restart-after 5000 --prefix-colors cyan,white,yellow",
       'start:addon': `npm start --workspace ${addonName}`,
-      'start:test': `npm start --workspace ${testAppName}`,
+      'start:test-app': `npm start --workspace ${testAppName}`,
       test: 'npm run test --workspaces --if-present',
     };
   },
@@ -79,7 +79,7 @@ let scripts = {
       prepare: 'yarn build',
       start: "concurrently 'npm:start:*' --restart-after 5000 --prefix-colors cyan,white,yellow",
       'start:addon': `yarn workspace ${addonName} run start`,
-      'start:test': `yarn workspace ${testAppName} run start`,
+      'start:test-app': `yarn workspace ${testAppName} run start`,
       test: 'yarn workspaces run test',
     };
   },
@@ -114,7 +114,7 @@ let scripts = {
        */
       start: "concurrently 'npm:start:*' --restart-after 5000 --prefix-colors cyan,white,yellow",
       'start:addon': `pnpm --filter ${addonName} start`,
-      'start:test': `pnpm --filter ${testAppName} start`,
+      'start:test-app': `pnpm --filter ${testAppName} start`,
       /**
        * Note that this test is different from v1 addon's test, which runs all of ember-try as well.
        * ember-try requires some alternate lockfile behaviors that we can't easily abstract into a

--- a/src/root-package-json.js
+++ b/src/root-package-json.js
@@ -51,17 +51,14 @@ let scripts = {
     } = info;
 
     return {
-      prepare: 'npm run build',
       build: `npm run build --workspace ${addonName}`,
-
-      start: "concurrently 'npm:start:*' --restart-after 5000 --prefix-colors cyan,white,yellow",
-      'start:tests': `npm start --workspace ${testAppName}`,
-      'start:addon': `npm start --workspace ${addonName} -- --no-watch.clearScreen`,
-
-      test: `npm test --workspace ${testAppName}`,
-
       lint: 'npm run lint --workspaces --if-present',
       'lint:fix': 'npm run lint:fix --workspaces --if-present',
+      prepare: 'npm run build',
+      start: "concurrently 'npm:start:*' --restart-after 5000 --prefix-colors cyan,white,yellow",
+      'start:addon': `npm start --workspace ${addonName} -- --no-watch.clearScreen`,
+      'start:tests': `npm start --workspace ${testAppName}`,
+      test: `npm test --workspace ${testAppName}`,
     };
   },
 
@@ -76,17 +73,14 @@ let scripts = {
     } = info;
 
     return {
-      prepare: `yarn build`,
       build: `yarn workspace ${addonName} run build`,
-
+      lint: 'yarn workspaces run lint',
+      'lint:fix': 'yarn workspaces run lint:fix',
+      prepare: `yarn build`,
       start: `concurrently 'npm:start:*' --restart-after 5000 --prefix-colors cyan,white,yellow`,
       'start:addon': `yarn workspace ${addonName} run start`,
       'start:test': `yarn workspace ${testAppName} run start`,
-
       test: 'yarn workspaces run test',
-
-      lint: 'yarn workspaces run lint',
-      'lint:fix': 'yarn workspaces run lint:fix',
     };
   },
 
@@ -101,13 +95,15 @@ let scripts = {
     } = info;
 
     return {
+      build: `pnpm --filter ${addonName} build`,
+      lint: "pnpm --filter '*' lint",
+      'lint:fix': "pnpm --filter '*' lint:fix",
       /**
        * For most optimized C.I., this will likely want to be removed, but
        * the prepare scripts helps folks get going quicker without having to understand
        * that every step in C.I. that needs the addon also needs the addon to be built first.
        */
       prepare: `pnpm build`,
-      build: `pnpm --filter ${addonName} build`,
       /**
        * restart-after exists because ember-cli continually crashes
        * when addon code changes from underneath it.
@@ -117,9 +113,8 @@ let scripts = {
        * Colors are customizable
        */
       start: "concurrently 'npm:start:*' --restart-after 5000 --prefix-colors cyan,white,yellow",
-      'start:tests': `pnpm --filter ${testAppName} start`,
       'start:addon': `pnpm --filter ${addonName} start --no-watch.clearScreen`,
-
+      'start:tests': `pnpm --filter ${testAppName} start`,
       /**
        * Note that this test is different from v1 addon's test, which runs all of ember-try as well.
        * ember-try requires some alternate lockfile behaviors that we can't easily abstract into a
@@ -127,9 +122,6 @@ let scripts = {
        *  (this is a consequence of enforced strict peers)
        */
       test: `pnpm --filter ${testAppName} test`,
-
-      lint: "pnpm --filter '*' lint",
-      'lint:fix': "pnpm --filter '*' lint:fix",
     };
   },
 };

--- a/src/root-package-json.js
+++ b/src/root-package-json.js
@@ -56,9 +56,9 @@ let scripts = {
       'lint:fix': 'npm run lint:fix --workspaces --if-present',
       prepare: 'npm run build',
       start: "concurrently 'npm:start:*' --restart-after 5000 --prefix-colors cyan,white,yellow",
-      'start:addon': `npm start --workspace ${addonName} -- --no-watch.clearScreen`,
-      'start:tests': `npm start --workspace ${testAppName}`,
-      test: `npm test --workspace ${testAppName}`,
+      'start:addon': `npm start --workspace ${addonName}`,
+      'start:test': `npm start --workspace ${testAppName}`,
+      test: 'npm run test --workspaces --if-present',
     };
   },
 
@@ -76,8 +76,8 @@ let scripts = {
       build: `yarn workspace ${addonName} run build`,
       lint: 'yarn workspaces run lint',
       'lint:fix': 'yarn workspaces run lint:fix',
-      prepare: `yarn build`,
-      start: `concurrently 'npm:start:*' --restart-after 5000 --prefix-colors cyan,white,yellow`,
+      prepare: 'yarn build',
+      start: "concurrently 'npm:start:*' --restart-after 5000 --prefix-colors cyan,white,yellow",
       'start:addon': `yarn workspace ${addonName} run start`,
       'start:test': `yarn workspace ${testAppName} run start`,
       test: 'yarn workspaces run test',
@@ -103,7 +103,7 @@ let scripts = {
        * the prepare scripts helps folks get going quicker without having to understand
        * that every step in C.I. that needs the addon also needs the addon to be built first.
        */
-      prepare: `pnpm build`,
+      prepare: 'pnpm build',
       /**
        * restart-after exists because ember-cli continually crashes
        * when addon code changes from underneath it.
@@ -113,15 +113,15 @@ let scripts = {
        * Colors are customizable
        */
       start: "concurrently 'npm:start:*' --restart-after 5000 --prefix-colors cyan,white,yellow",
-      'start:addon': `pnpm --filter ${addonName} start --no-watch.clearScreen`,
-      'start:tests': `pnpm --filter ${testAppName} start`,
+      'start:addon': `pnpm --filter ${addonName} start`,
+      'start:test': `pnpm --filter ${testAppName} start`,
       /**
        * Note that this test is different from v1 addon's test, which runs all of ember-try as well.
        * ember-try requires some alternate lockfile behaviors that we can't easily abstract into a
        * package.json script -- but will be present in C.I.
        *  (this is a consequence of enforced strict peers)
        */
-      test: `pnpm --filter ${testAppName} test`,
+      test: "pnpm --filter '*' test",
     };
   },
 };


### PR DESCRIPTION
## Background

While studying the blueprint files to implement [`ember-codemod-v1-to-v2`](https://github.com/ijlee2/ember-codemod-v1-to-v2/), I noticed that the scripts in the root `package.json` differ among `npm`, `pnpm`, and `yarn`.

The scripts are also not alphabetized by name. In my experience, unsorted keys make maintenance difficult (a pairwise comparison of keys of a POJO is time-consuming) and increase noise in a pull request, if an end-developer uses a tool like [`sort-package-json`](https://www.npmjs.com/package/sort-package-json) to keep `package.json`'s in a monorepo consistent.

I opened this pull request so that I can also ask a couple of questions for clarity.


## How to Review

I recommend reviewing the commits one by one. The keys are sorted in the 1st commit; the scripts are standardized in the 2nd commit.