### PR TITLE
New flag: --addon-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,12 +55,12 @@ jobs:
           - addon-location
           - test-app-location
           - typescript
+          - addon-only
 
           # existing monorepo
           - monorepo with npm
           - monorepo with yarn
           - monorepo with pnpm
-          - addon-only
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/pnpm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,7 @@ jobs:
           - monorepo with npm
           - monorepo with yarn
           - monorepo with pnpm
+          - addon-only
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/pnpm

--- a/README.md
+++ b/README.md
@@ -101,6 +101,24 @@ ember addon my-addon -b @embroider/addon-blueprint --test-app-name=test-app-for-
 
 By default, `test-app` will be used.
 
+### `--addon-only`
+
+Will only create the addon, similar to the v1 addon behavior of `ember addon my-addon`. 
+This is useful for incremental migrations of v1 addons to v2 addons where the process from the 
+[Porting Addons to V2](https://github.com/embroider-build/embroider/blob/main/PORTING-ADDONS-TO-V2.md)
+guide.
+
+```bash
+ember addon my-addon -b @embroider/addon-blueprint --addon-only
+# generates non-monorepo:
+#   my-addon/
+#     .git 
+#     package.json
+```
+
+For incremental migration in monorepos, you'll want to also supply the `--skip-git` flag.
+
+
 #### `--release-it`
 
 If you want release-it behavior, (specifically provided by `create-rwjblue-release-it-setup`),

--- a/index.js
+++ b/index.js
@@ -218,7 +218,7 @@ module.exports = {
   },
 
   fileMapTokens(options) {
-    let { addonInfo, testAppInfo, ext, typescript } = options.locals;
+    let { addonInfo, testAppInfo, ext } = options.locals;
 
     return {
       __addonLocation__: () => addonInfo.location,

--- a/index.js
+++ b/index.js
@@ -296,7 +296,7 @@ module.exports = {
     let files = this._super.files.apply(this, arguments);
 
     if (options.addonOnly) {
-      files = files.filter((filename) => !filename.includes('test-app-overrides'));
+      files = files.filter((filename) => filename.includes('__addonLocation__'));
     }
 
     if (options.typescript) {

--- a/src/info.js
+++ b/src/info.js
@@ -14,6 +14,11 @@ function addonInfoFromOptions(options) {
   let addonEntity = options.entity;
   let addonRawName = addonEntity.name;
   let dashedName = stringUtil.dasherize(addonRawName);
+  let location = options.addonLocation || dashedName;
+
+  if (options.addonOnly) {
+    location = '.';
+  }
 
   return {
     packageName: dashedName,
@@ -23,7 +28,7 @@ function addonInfoFromOptions(options) {
       raw: addonRawName,
     },
     entity: addonEntity,
-    location: options.addonLocation || dashedName,
+    location,
   };
 }
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -516,12 +516,12 @@ describe('ember addon <the addon> -b <this blueprint>', () => {
     beforeAll(async () => {
       tmpDir = await createTmp();
 
-      await createAddon({
+      let { name } = await createAddon({
         args: ['--addon-only', '--pnpm=true'],
         options: { cwd: tmpDir },
       });
 
-      cwd = tmpDir;
+      cwd = path.join(tmpDir, name);
 
       await install({ cwd, packageManager: 'pnpm' });
     });

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -508,4 +508,47 @@ describe('ember addon <the addon> -b <this blueprint>', () => {
       });
     });
   });
+
+  describe('--addon-only', () => {
+    let cwd = '';
+    let tmpDir = '';
+
+    beforeAll(async () => {
+      tmpDir = await createTmp();
+
+      await createAddon({
+        args: ['--addon-only', '--pnpm=true'],
+        options: { cwd: tmpDir },
+      });
+
+      cwd = tmpDir;
+
+      await install({ cwd, packageManager: 'pnpm' });
+    });
+
+    afterAll(async () => {
+      fs.rm(tmpDir, { recursive: true, force: true });
+    });
+
+    it('is not a monorepo', async () => {
+      let hasPnpmWorkspace = await fse.pathExists(path.join(cwd, 'pnpm-workspace.yaml'));
+      let packageJson = await fse.readJson(path.join(cwd, 'package.json'));
+
+      expect(hasPnpmWorkspace).toBe(false);
+      // Pnpm doesn't use this field, but it's good that it doesn't exist.
+      expect(packageJson.workspaces).toBeFalsy();
+    });
+
+    it('can build', async () => {
+      let { exitCode } = await runScript({ cwd, script: 'build', packageManager: 'pnpm' });
+
+      expect(exitCode).toEqual(0);
+    });
+
+    it('has passing lints', async () => {
+      let { exitCode } = await runScript({ cwd, script: 'lint', packageManager: 'pnpm' });
+
+      expect(exitCode).toEqual(0);
+    });
+  });
 });


### PR DESCRIPTION
This will greatly help automated tooling in that it will be able to support the multi-PR style of converting v1 addons to v2 addons.

The goal is to support the _Porting Addons to V2_ workflow, where the process is to do these separately:
 - split test-app from v1 addon
 - convert v1 addon to v2
 
 In order to do that second step, the addon-blueprint needs an option to be able to _just do the addon part_, because we want tell this blueprint to assume there are already tests _somewhere_ for the addon being converted.
 
 This makes this v2 addon blueprint function much the same as the existing v1 addon blueprint, in that there is no monorepo assumptions, and the generation of the addon happens "in place" with a single package.json.
 
 This happens to also greatly lift the burden of "fix everything upstream before we can do a simple thing" (`--typescript`, atm -- a side-effect of enabling two-step conversion, which will be supplemented by https://github.com/NullVoxPopuli/ember-addon-migrator/ via `npx ember-addon-migrator extract-tests ../to/path` (or something similar))