### PR TITLE
allowDeclareFields for TS projects, by default

### DIFF
--- a/files/__addonLocation__/babel.config.json
+++ b/files/__addonLocation__/babel.config.json
@@ -1,6 +1,7 @@
 {
 <% if (typescript) { %>  "presets": [["@babel/preset-typescript"]],
-<% } %>  "plugins": [
+<% } %>  "plugins": [<% if (typescript) { %>
+    ["@babel/plugin-transform-typescript", { "allowDeclareFields": true }],<% } %>
     "@embroider/addon-dev/template-colocation-plugin",
     ["@babel/plugin-proposal-decorators", { "legacy": true }],
     "@babel/plugin-proposal-class-properties"


### PR DESCRIPTION
Without this, our community-recommended way of using services doesn't work.
```ts
class Demo {
  @service declare property: Type;
}
```
You end up getting an error that babel isn't configured to use declare fields.

This avoids passing config to `preset-typescript` directly, due to the investigation in this bigger pr: https://github.com/embroider-build/addon-blueprint/pull/89 where the options appear to _not be used at all_.
(and I confirmed that this is still the case, many weeks later (today))

To test this change, checkout this branch, and run: 
```
npx ember-cli addon ts-addon -b path/to/local/addon-blueprint/ --skip-git --skip-npm --typescript --addon-only
```

add a class with a `@service` and build.
I used this in the generated `src/index.ts`
```ts
import { service } from '@ember/service';

export class Demo {
  @service declare foo: unknown;
}
```