### PR TITLE
Upgrade addon dependencies

### DIFF
--- a/files/__addonLocation__/.eslintrc.cjs
+++ b/files/__addonLocation__/.eslintrc.cjs
@@ -50,8 +50,8 @@ module.exports = {
         browser: false,
         node: true,
       },
-      plugins: ['node'],
-      extends: ['plugin:node/recommended'],
+      plugins: ['n'],
+      extends: ['plugin:n/recommended'],
     },
   ],
 };

--- a/files/__addonLocation__/package.json
+++ b/files/__addonLocation__/package.json
@@ -39,7 +39,7 @@
     "@glint/core": "^1.0.2",
     "@glint/environment-ember-loose": "^1.0.2",
     "@glint/template": "^1.0.2",
-    "@tsconfig/ember": "^1.0.0",
+    "@tsconfig/ember": "^2.0.0",
     "@types/ember": "^4.0.0",
     "@types/ember__object": "^4.0.0",
     "@types/ember__service": "^4.0.0",
@@ -59,19 +59,19 @@
     "@types/ember__routing": "^4.0.0",
     "@typescript-eslint/eslint-plugin": "^5.30.5",
     "@typescript-eslint/parser": "^5.30.5",<% } else { %>
-    "@rollup/plugin-babel": "^5.3.0",<% } %>
-    "concurrently": "^7.2.1",
-    "ember-template-lint": "^4.0.0",
+    "@rollup/plugin-babel": "^6.0.3",<% } %>
+    "concurrently": "^8.0.1",
+    "ember-template-lint": "^5.7.3",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.3.0",
-    "eslint-plugin-ember": "^10.5.8",
-    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-ember": "^11.6.0",
+    "eslint-plugin-n": "^16.0.0",
     "eslint-plugin-prettier": "^4.0.0",
     "prettier": "^2.5.1",
-    "rollup": "^2.67.0"<% if (!isExistingMonorepo) { %>,
+    "rollup": "^3.21.8"<% if (!isExistingMonorepo) { %>,
     "rollup-plugin-copy": "^3.4.0"<% } %><% if (typescript) { %>,
     "rollup-plugin-ts": "^3.0.2",
-    "typescript": "^4.9.5"<% } %>
+    "typescript": "^5.0.4"<% } %>
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"


### PR DESCRIPTION
A good number of these were out of date.

May confilct with: https://github.com/embroider-build/addon-blueprint/pull/118

Some of the lint deps were not updated, because they require config changes (eslint 8, etc)

After this is merged, I'll throw up a PR that updates the lints 
(or update this one: https://github.com/embroider-build/addon-blueprint/pull/108 )