### PR TITLE
Avoid duplicate workspace names.

### DIFF
--- a/files/package.json
+++ b/files/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "<%= addonName %>",
+  "name": "<%= addonName %>-monorepo",
   "version": "0.0.0",
   "private": true,
   "repository": "",


### PR DESCRIPTION
Discovered while debugging: https://github.com/embroider-build/addon-blueprint/pull/118
If someone wants to use a newer yarn, they get this error:
```
🚧  Installing packages... This might take a couple of minutes.
Command failed with exit code 1: yarn add --dev ember-cli-typescript
Internal Error: Duplicate workspace name ts-project: /Users/psego/Development/tmp/ts-project/ts-project conflicts with /Users/psego/Development/tmp/ts-project
    at St.addWorkspace (/Users/psego/.volta/tools/image/yarn/4.0.0-rc.42/bin/yarn.js:204:1949)
    at async St.setupWorkspaces (/Users/psego/.volta/tools/image/yarn/4.0.0-rc.42/bin/yarn.js:204:1735)
    at async Function.find (/Users/psego/.volta/tools/image/yarn/4.0.0-rc.42/bin/yarn.js:201:8463)
    at async P0.execute (/Users/psego/.volta/tools/image/yarn/4.0.0-rc.42/bin/yarn.js:386:14007)
    at async P0.validateAndExecute (/Users/psego/.volta/tools/image/yarn/4.0.0-rc.42/bin/yarn.js:91:12775)
    at async vo.run (/Users/psego/.volta/tools/image/yarn/4.0.0-rc.42/bin/yarn.js:95:3074)
    at async vo.runExit (/Users/psego/.volta/tools/image/yarn/4.0.0-rc.42/bin/yarn.js:95:3258)
    at async o (/Users/psego/.volta/tools/image/yarn/4.0.0-rc.42/bin/yarn.js:386:4014)
    at async r (/Users/psego/.volta/tools/image/yarn/4.0.0-rc.42/bin/yarn.js:386:2118)


Stack Trace and Error Report: /var/folders/wk/w99lck4x7_5930c7gj65r3s40000gp/T/error.dump.2e2f8c9d013a9b63fda95e62ac7d25ac.log

 ~/Development/tmp took 14s
❯  yarn --version
4.0.0-rc.42
```