### PR TITLE
Add gjs/gts support

### DIFF
--- a/files/__addonLocation__/babel.config.json
+++ b/files/__addonLocation__/babel.config.json
@@ -1,6 +1,7 @@
 {
 <% if (typescript) { %>  "presets": [["@babel/preset-typescript"]],
 <% } %>  "plugins": [
+    "ember-template-imports/src/babel-plugin",
     "@embroider/addon-dev/template-colocation-plugin",
     ["@babel/plugin-proposal-decorators", { "legacy": true }],
     "@babel/plugin-proposal-class-properties"

--- a/files/__addonLocation__/package.json
+++ b/files/__addonLocation__/package.json
@@ -68,8 +68,8 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^4.0.0",
     "prettier": "^2.5.1",
-    "rollup": "^2.67.0"<% if (!isExistingMonorepo) { %>,
-    "rollup-plugin-copy": "^3.4.0"<% } %>
+    "rollup": "^2.67.0",<% if (!isExistingMonorepo) { %>
+    "rollup-plugin-copy": "^3.4.0",<% } %>
     "rollup-plugin-glimmer-template-tag"<% if (typescript) { %>,
     "rollup-plugin-ts": "^3.0.2",
     "typescript": "^4.9.5"<% } %>

--- a/files/__addonLocation__/package.json
+++ b/files/__addonLocation__/package.json
@@ -69,7 +69,8 @@
     "eslint-plugin-prettier": "^4.0.0",
     "prettier": "^2.5.1",
     "rollup": "^2.67.0"<% if (!isExistingMonorepo) { %>,
-    "rollup-plugin-copy": "^3.4.0"<% } %><% if (typescript) { %>,
+    "rollup-plugin-copy": "^3.4.0"<% } %>
+    "rollup-plugin-glimmer-template-tag"<% if (typescript) { %>,
     "rollup-plugin-ts": "^3.0.2",
     "typescript": "^4.9.5"<% } %>
   },

--- a/files/__addonLocation__/package.json
+++ b/files/__addonLocation__/package.json
@@ -70,7 +70,7 @@
     "prettier": "^2.5.1",
     "rollup": "^2.67.0",<% if (!isExistingMonorepo) { %>
     "rollup-plugin-copy": "^3.4.0",<% } %>
-    "rollup-plugin-glimmer-template-tag"<% if (typescript) { %>,
+    "rollup-plugin-glimmer-template-tag": "^0.4.1"<% if (typescript) { %>,
     "rollup-plugin-ts": "^3.0.2",
     "typescript": "^4.9.5"<% } %>
   },

--- a/files/__addonLocation__/rollup.config.mjs
+++ b/files/__addonLocation__/rollup.config.mjs
@@ -1,6 +1,7 @@
 <% if (typescript) { %>import typescript from 'rollup-plugin-ts';<% } else { %>import { babel } from '@rollup/plugin-babel';<% } %>
 <% if (!isExistingMonorepo) { %>import copy from 'rollup-plugin-copy';
 <% } %>import { Addon } from '@embroider/addon-dev/rollup';
+import { glimmerTemplateTag } from 'rollup-plugin-glimmer-template-tag';
 
 const addon = new Addon({
   srcDir: 'src',
@@ -31,7 +32,7 @@ export default {
     typescript({
       transpiler: 'babel',
       browserslist: false,
-      transpileOnly: false,
+      transpileOnly: true,
     }),
 <% } else { %>    // This babel config should *not* apply presets or compile away ES modules.
     // It exists only to provide development niceties for you, like automatic
@@ -45,6 +46,7 @@ export default {
 <% } %>
     // Ensure that standalone .hbs files are properly integrated as Javascript.
     addon.hbs(),
+    glimmerTemplateTag(),
 
     // addons are allowed to contain imports of .css files, which we want rollup
     // to leave alone and keep in the published output.


### PR DESCRIPTION
Adds https://github.com/NullVoxPopuli/rollup-plugin-glimmer-template-tag
_However_
  adding `rollup-plugin-glimmer-template-tag` as a devDependency then _requires_
   - adding ember-source 
     - fine, handled by https://github.com/embroider-build/addon-blueprint/pull/118 )
       - except that for monorepos, we can't support yarn@v1
         - unless we allow this all to be blocked by the `--typescript` app blueprint using the built-in types, semi-related: https://github.com/ember-cli/ember-cli/pull/10216
           (the problem is that the `@types/ember*` packages and the built in types aren't perfectly compatible)
       - adding ember-source, in turn, requires consumers install `@glimmer/component` (I think for types), and `webpack`. for libraries webpack is unreasonable (and unused), but `@glimmer/component`, is 🤷 a good number of v2 addons will need it anyway (and is [added here](https://github.com/embroider-build/addon-blueprint/pull/118/files#diff-931f0024f6b4877d9d8516d7f8f63f4f854d73614de449600db128823902a82dR42))   For webpack, we'll want to add a [`pnpm.peerDependencyRules.ignoreMissing`](https://pnpm.io/package_json#pnpmpeerdependencyrulesignoremissing) entry
   - adding ember-template-imports
     - not fine, but https://github.com/ember-template-imports/ember-template-imports/issues/143 will help resolve
       - waiting on @achambers & co to publish
       - then waiting on me to update rollup-plugin-glimmer-template-tag to use the new stuff



## To Test

1. checkout locally
2. `cd $elsewhere`
3. `npx ember-cli@latest addon gjs-addon -b $addonBlueprint/ --skip-npm --skip-git --addon-only`
4. `cd gjs-addon`
5. `pnpm i`
6. `pnpm build`