### PR TITLE
Add note for workaround for --typescript issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,28 @@ This is still work in progress.
 
 The blueprint contains a number of assumptions, e.g. using a monorepo using (`yarn` or `npm`) workspaces, with separate workspaces for the addon and the test-app. But there is plenty of room for bikeshedding here, so if you have suggestions about better ways to set this up, then please file an issue to discuss!
 
+### Temporary work-around for `--typescript` issues
+
+Today, `--typescript` is implemented via differing to `ember-cli`'s `--typescript` when generating the test-app.
+This has a number of issues:
+ - `ember-cli-typescript` is very out of date
+   - remove `@types/ember__test-helpers` and `@types/ember-test-helpers` (`@ember/test-helpers` provides its own types)
+ - peer issues with ember-cli cause the generation of a whole project to be deleted by ember-cli
+ - the package manager is ignored when ember-cli defers to `ember-cli-typescript`s blueprint
+ - there is no way to opt out of ember-cli installing dependencies when using `--typescript`
+ 
+To make a monorepo manually:
+```bash
+mkdir my-monorepo
+cd my-monorepo
+git init
+touch package.json # make sure to fill this out
+npx ember-cli@latest addon my-addon -b @embroider/addon-blueprint --skip-git --skip-npm --typescript --addon-only
+npx ember-cli@latest new test-app --skip-git --skip-npm --typescript # make sure to add the addon as a dependency in the test-app
+```
+
+We're actively trying to make this situation better, but this is what we have to deal with until `--typescript` support in ember-cli is more stable (and maybe uses the built-in types).
+
 ## Usage
 
 ```bash


### PR DESCRIPTION
People are using the v2 addon blueprint, and when trying to use `--typescript`, there are undocumented / hard to find issues with how `--typescript` works in ember-cli right now.

This README updates documents some of those, and adds some manual instructions so folks get be unblocked.
(It's important to unblock folks _while_ we work on a proper solution, as folks *want* to do what they want to do, and we/I need to enable them 🎉 )