### PR TITLE
Updated the addon package's Babel configuration

### DIFF
--- a/files/__addonLocation__/babel.config.json
+++ b/files/__addonLocation__/babel.config.json
@@ -3,7 +3,7 @@
 <% } %>  "plugins": [<% if (typescript) { %>
     ["@babel/plugin-transform-typescript", { "allowDeclareFields": true }],<% } %>
     "@embroider/addon-dev/template-colocation-plugin",
-    ["@babel/plugin-proposal-decorators", { "decoratorsBeforeExport": true }],
+    ["@babel/plugin-proposal-decorators", { "legacy": true }],
     "@babel/plugin-proposal-class-properties"
   ]
 }

--- a/files/__addonLocation__/babel.config.json
+++ b/files/__addonLocation__/babel.config.json
@@ -1,8 +1,8 @@
 {
 <% if (typescript) { %>  "presets": [["@babel/preset-typescript"]],
-<% } %>  "plugins": [<% if (typescript) { %>
+<% } %>  "plugins": [
+    "@embroider/addon-dev/template-colocation-plugin",<% if (typescript) { %>
     ["@babel/plugin-transform-typescript", { "allowDeclareFields": true }],<% } %>
-    "@embroider/addon-dev/template-colocation-plugin",
     ["@babel/plugin-proposal-decorators", { "legacy": true }],
     "@babel/plugin-proposal-class-properties"
   ]

--- a/files/__addonLocation__/babel.config.json
+++ b/files/__addonLocation__/babel.config.json
@@ -3,7 +3,7 @@
 <% } %>  "plugins": [
     "@embroider/addon-dev/template-colocation-plugin",<% if (typescript) { %>
     ["@babel/plugin-transform-typescript", { "allowDeclareFields": true }],<% } %>
-    ["@babel/plugin-proposal-decorators", { "legacy": true }],
+    ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
     "@babel/plugin-proposal-class-properties"
   ]
 }

--- a/files/__addonLocation__/package.json
+++ b/files/__addonLocation__/package.json
@@ -33,7 +33,6 @@
     <% if (typescript) { %>"@babel/preset-typescript": "^7.18.6"<% } else { %>"@babel/eslint-parser": "^7.19.1"<% } %>,
     "@babel/plugin-proposal-class-properties": "^7.16.7",
     "@babel/plugin-proposal-decorators": "^7.20.13",
-    "@babel/plugin-syntax-decorators": "^7.17.0",
     "@babel/runtime": "^7.17.0",
     "@embroider/addon-dev": "^3.0.0",<% if (typescript) { %>
     "@glint/core": "^1.0.2",


### PR DESCRIPTION
## Description

I introduced a few changes to the Babel configuration for v2 addons:

- Changed the default option for `@babel/plugin-proposal-decorators` to `{ "legacy": true }` (to address [a bug](https://github.com/embroider-build/addon-blueprint/pull/108#discussion_r1210662259)), then to `{ "version": "legacy" }` (to address [a deprecation](https://babeljs.io/docs/babel-plugin-proposal-decorators#legacy))

    > Use version: "legacy" instead. This option is a legacy alias.

- Reordered the plugins to group Babel plugins together

- Removed `@babel/plugin-syntax-decorators` (unused) from `package.json`

The latter two code changes may be considered new to `@embroider/addon-blueprint`. I've created and used v2 addons with these changes for about 3 months, so I think we can consider the changes safe to implement.


## Notes

The failing status check `Tests (typescript)`, with the error message `Cannot find module '@babel/plugin-proposal-object-rest-spread'`, is unrelated to this pull request.

<img width="800" alt="" src="https://github.com/embroider-build/addon-blueprint/assets/16869656/e7833fb9-a073-4030-852f-5db7ea5ab55e">

I encountered the error message while trying to update the dependencies of `ember-container-query` (failed in [#194](https://github.com/ijlee2/ember-container-query/pull/194), then later succeeded in [#196](https://github.com/ijlee2/ember-container-query/pull/196) and [#197](https://github.com/ijlee2/ember-container-query/pull/197)).

According to https://github.com/babel/babel/issues/15670#issuecomment-1569606333, the issue might have been caused by `rollup-plugin-ts` not declaring `@babel/plugin-proposal-object-rest-spread` as a dependency or peer dependency.