### PR TITLE
Fix `cd <path>` in CONTRIBUTING.md

### DIFF
--- a/files/CONTRIBUTING.md
+++ b/files/CONTRIBUTING.md
@@ -1,12 +1,12 @@
 # How To Contribute
 
-## Installation
+<% if (!isExistingMonorepo) { %>## Installation
 
 - `git clone <repository-url>`
-- `cd <%= addonName %>`
+- `cd <%= rootDirectory %>`
 - `<% if (yarn) { %>yarn<% } else if (pnpm) { %>pnpm<% } else { %>npm<% } %> install`
 
-## Linting
+<% } %>## Linting
 
 - `<% if (yarn) { %>yarn lint<% } else if (pnpm) { %>pnpm lint<% } else { %>npm run lint<% } %>`
 - `<% if (yarn) { %>yarn lint:fix<% } else if (pnpm) { %>pnpm lint:fix<% } else { %>npm run lint:fix<% } %>`

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ let date = new Date();
 const { addonInfoFromOptions, testAppInfoFromOptions, withoutAddonOptions } = require('./src/info');
 const { scripts } = require('./src/root-package-json');
 const pnpm = require('./src/pnpm');
+const directoryForPackageName = require('./src/directory-for-package-name');
 
 const description = 'The default blueprint for Embroider v2 addons.';
 
@@ -264,6 +265,7 @@ module.exports = {
       .join('/');
 
     return {
+      rootDirectory: directoryForPackageName(addonInfo.name.raw),
       addonInfo,
       testAppInfo,
       addonName: addonInfo.name.dashed,

--- a/src/directory-for-package-name.js
+++ b/src/directory-for-package-name.js
@@ -1,0 +1,33 @@
+'use strict';
+
+// copied from https://github.com/ember-cli/ember-cli/blob/1c2b61920576dfe83dc27e0e55a89fb8b1240676/lib/tasks/create-and-step-into-directory.js
+
+const path = require('path');
+
+/**
+ * Derive a directory name from a package name.
+ * Takes scoped packages into account.
+ *
+ * @method directoryForPackageName
+ * @param {String} packageName
+ * @return {String} Derived directory name.
+ */
+module.exports = function directoryForPackageName(packageName) {
+  let isScoped = packageName[0] === '@' && packageName.includes('/');
+
+  if (isScoped) {
+    let slashIndex = packageName.indexOf('/');
+    let scopeName = packageName.substring(1, slashIndex);
+    let packageNameWithoutScope = packageName.substring(slashIndex + 1);
+    let pathParts = process.cwd().split(path.sep);
+    let parentDirectoryContainsScopeName = pathParts.includes(scopeName);
+
+    if (parentDirectoryContainsScopeName) {
+      return packageNameWithoutScope;
+    } else {
+      return `${scopeName}-${packageNameWithoutScope}`;
+    }
+  } else {
+    return packageName;
+  }
+};

--- a/tests/fixtures/default/CONTRIBUTING.md
+++ b/tests/fixtures/default/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# How To Contribute
+
+## Installation
+
+- `git clone <repository-url>`
+- `cd my-addon`
+- `npm install`
+
+## Linting
+
+- `npm run lint`
+- `npm run lint:fix`
+
+## Building the addon
+
+- `cd my-addon`
+- `npm build`
+
+## Running tests
+
+- `cd test-app`
+- `npm run test` – Runs the test suite on the current Ember version
+- `npm run test:watch` – Runs the test suite in "watch mode"
+
+## Running the test application
+
+- `cd test-app`
+- `npm run start`
+- Visit the test application at [http://localhost:4200](http://localhost:4200).
+
+For more information on using ember-cli, visit [https://cli.emberjs.com/release/](https://cli.emberjs.com/release/).

--- a/tests/fixtures/pnpm/CONTRIBUTING.md
+++ b/tests/fixtures/pnpm/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# How To Contribute
+
+## Installation
+
+- `git clone <repository-url>`
+- `cd my-addon`
+- `pnpm install`
+
+## Linting
+
+- `pnpm lint`
+- `pnpm lint:fix`
+
+## Building the addon
+
+- `cd my-addon`
+- `pnpm build`
+
+## Running tests
+
+- `cd test-app`
+- `pnpm test` – Runs the test suite on the current Ember version
+- `pnpm test:watch` – Runs the test suite in "watch mode"
+
+## Running the test application
+
+- `cd test-app`
+- `pnpm start`
+- Visit the test application at [http://localhost:4200](http://localhost:4200).
+
+For more information on using ember-cli, visit [https://cli.emberjs.com/release/](https://cli.emberjs.com/release/).

--- a/tests/fixtures/yarn/CONTRIBUTING.md
+++ b/tests/fixtures/yarn/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# How To Contribute
+
+## Installation
+
+- `git clone <repository-url>`
+- `cd my-addon`
+- `yarn install`
+
+## Linting
+
+- `yarn lint`
+- `yarn lint:fix`
+
+## Building the addon
+
+- `cd my-addon`
+- `yarn build`
+
+## Running tests
+
+- `cd test-app`
+- `yarn test` – Runs the test suite on the current Ember version
+- `yarn test:watch` – Runs the test suite in "watch mode"
+
+## Running the test application
+
+- `cd test-app`
+- `yarn start`
+- Visit the test application at [http://localhost:4200](http://localhost:4200).
+
+For more information on using ember-cli, visit [https://cli.emberjs.com/release/](https://cli.emberjs.com/release/).

--- a/tests/smoke-tests/defaults.test.ts
+++ b/tests/smoke-tests/defaults.test.ts
@@ -32,7 +32,9 @@ for (let packageManager of SUPPORTED_PACKAGE_MANAGERS) {
       let yarn = path.join(helper.projectRoot, 'yarn.lock');
       let pnpm = path.join(helper.projectRoot, 'pnpm-lock.yaml');
 
-      let testManifest = await fse.readJson(path.join(helper.projectRoot, 'test-app', 'package.json'));
+      let testManifest = await fse.readJson(
+        path.join(helper.projectRoot, 'test-app', 'package.json')
+      );
 
       switch (packageManager) {
         case 'npm': {
@@ -42,6 +44,7 @@ for (let packageManager of SUPPORTED_PACKAGE_MANAGERS) {
 
           await matchesFixture('.github/workflows/ci.yml', { cwd: helper.projectRoot });
           await matchesFixture('.github/workflows/push-dist.yml', { cwd: helper.projectRoot });
+          await matchesFixture('CONTRIBUTING.md', { cwd: helper.projectRoot });
 
           expect(testManifest.devDependencies['my-addon']).toBe('^0.0.0');
 
@@ -60,6 +63,7 @@ for (let packageManager of SUPPORTED_PACKAGE_MANAGERS) {
             cwd: helper.projectRoot,
             scenario: 'yarn',
           });
+          await matchesFixture('CONTRIBUTING.md', { cwd: helper.projectRoot, scenario: 'yarn' });
 
           expect(testManifest.devDependencies['my-addon']).toBe('^0.0.0');
 
@@ -78,7 +82,7 @@ for (let packageManager of SUPPORTED_PACKAGE_MANAGERS) {
             cwd: helper.projectRoot,
             scenario: 'pnpm',
           });
-
+          await matchesFixture('CONTRIBUTING.md', { cwd: helper.projectRoot, scenario: 'pnpm' });
 
           expect(testManifest.devDependencies['my-addon']).toBe('workspace:*');
 
@@ -114,7 +118,7 @@ for (let packageManager of SUPPORTED_PACKAGE_MANAGERS) {
       await helper.fixtures.use('./test-app/tests');
 
       // Ensure that we have no lint errors.
-      // It's important to keep this along with the tests, 
+      // It's important to keep this along with the tests,
       // so that we can have confidence that the lints aren't destructively changing
       // the files in a way that would break consumers
       let { exitCode } = await helper.run('lint:fix');


### PR DESCRIPTION
For scoped package names ( e.g `@foo/bar`) this will print the correct root path (`cd foo-bar`) and not the scoped packaged name (compare this to https://github.com/ember-cli/ember-cli/pull/9785). For existing monorepos, it will omit the whole "Installation" section.