### PR TITLE
Update for ember-cli `--typescript` changes

### DIFF
--- a/files/test-app-overrides/ember-cli-build.js
+++ b/files/test-app-overrides/ember-cli-build.js
@@ -4,7 +4,8 @@ const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
 module.exports = function (defaults) {
   let app = new EmberApp(defaults, {
-    autoImport: {
+    <% if (typescript) {%>'ember-cli-babel': { enableTypeScriptTransform: true },
+    <% } %>autoImport: {
       watchDependencies: ['<%= addonName %>'],
     },
   });


### PR DESCRIPTION
Update our blueprint to take account of changes when generating the test-app with `--typescript` ([PR](https://github.com/ember-cli/ember-cli/pull/10283)). The new blueprint now drops ember-cli-typescript and opts into the TS transform of ember-cli-babel, which we must not override.