### PR TITLE
Rearrange gitignore setup

### DIFF
--- a/files/__addonLocation__/gitignore
+++ b/files/__addonLocation__/gitignore
@@ -3,8 +3,3 @@
 # will also appear in published NPM packages.
 /README.md
 /LICENSE.md
-# Build output
-/dist/
-/declarations/
-# npm/pnpm/yarn pack output
-*.tgz

--- a/files/gitignore
+++ b/files/gitignore
@@ -2,6 +2,10 @@
 
 # compiled output
 dist/
+declarations/
+
+# npm/pnpm/yarn pack output
+*.tgz
 
 # dependencies
 node_modules/


### PR DESCRIPTION
#133 added changes to the addon's .gitignore. We now ignore `/dist` in the [root .gitignore](https://github.com/embroider-build/addon-blueprint/blob/main/files/gitignore#L4) and in the [addon's .gitignore](https://github.com/embroider-build/addon-blueprint/blob/main/files/__addonLocation__/gitignore#L7). That's redundant. The root's .gitignore scope was not to only ignore what's created at the root folder, but also what's inside the addon. All the stuff that we want to have ignored in general. The addon's .gitignore ignores what is specific only to that single folder, in this case the copied at build-time `README.md` and `LICENSE.md` files, which live at the root folder and therefore must not be ignored there, but only at the addon folder.