### PR TITLE
Add CI workflow to push dist output to separate branch

### DIFF
--- a/files/.github/workflows/push-dist.yml
+++ b/files/.github/workflows/push-dist.yml
@@ -1,0 +1,31 @@
+# Because this library needs to be built,
+# we can't easily point package.json files at the git repo for easy cross-repo testing.
+#
+# This workflow brings back that capability by placing the compiled assets on a "dist" branch
+# (configurable via the "branch" option below)
+name: Push dist
+
+on:
+  push:
+    branches:
+      - main
+      - master
+
+jobs:
+  push-dist:
+    name: Push dist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3<% if (pnpm) {%>
+      - uses: NullVoxPopuli/action-setup-pnpm@v2<%} else {%>
+      - name: Install Node
+        uses: actions/setup-node@v3
+        with:
+          cache: '<%= yarn ? 'yarn' : 'npm' %>'<% } if (yarn || npm) { %>
+      - name: Install Dependencies
+        run: <%= yarn ? 'yarn install --frozen-lockfile' : 'npm ci' %><%}%>
+      - uses: kategengler/put-built-npm-package-contents-on-branch@v1.0.0
+        with:
+          branch: dist
+          token: ${{ secrets.GITHUB_TOKEN }}
+          working-directory: <%= addonInfo.location %>

--- a/tests/fixtures/default/.github/workflows/push-dist.yml
+++ b/tests/fixtures/default/.github/workflows/push-dist.yml
@@ -1,0 +1,30 @@
+# Because this library needs to be built,
+# we can't easily point package.json files at the git repo for easy cross-repo testing.
+#
+# This workflow brings back that capability by placing the compiled assets on a "dist" branch
+# (configurable via the "branch" option below)
+name: Push dist
+
+on:
+  push:
+    branches:
+      - main
+      - master
+
+jobs:
+  push-dist:
+    name: Push dist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Node
+        uses: actions/setup-node@v3
+        with:
+          cache: 'npm'
+      - name: Install Dependencies
+        run: npm ci
+      - uses: kategengler/put-built-npm-package-contents-on-branch@v1.0.0
+        with:
+          branch: dist
+          token: ${{ secrets.GITHUB_TOKEN }}
+          working-directory: my-addon 

--- a/tests/fixtures/pnpm/.github/workflows/push-dist.yml
+++ b/tests/fixtures/pnpm/.github/workflows/push-dist.yml
@@ -1,0 +1,25 @@
+# Because this library needs to be built,
+# we can't easily point package.json files at the git repo for easy cross-repo testing.
+#
+# This workflow brings back that capability by placing the compiled assets on a "dist" branch
+# (configurable via the "branch" option below)
+name: Push dist
+
+on:
+  push:
+    branches:
+      - main
+      - master
+
+jobs:
+  push-dist:
+    name: Push dist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: NullVoxPopuli/action-setup-pnpm@v2
+      - uses: kategengler/put-built-npm-package-contents-on-branch@v1.0.0
+        with:
+          branch: dist
+          token: ${{ secrets.GITHUB_TOKEN }}
+          working-directory: my-addon

--- a/tests/fixtures/yarn/.github/workflows/push-dist.yml
+++ b/tests/fixtures/yarn/.github/workflows/push-dist.yml
@@ -1,0 +1,30 @@
+# Because this library needs to be built,
+# we can't easily point package.json files at the git repo for easy cross-repo testing.
+#
+# This workflow brings back that capability by placing the compiled assets on a "dist" branch
+# (configurable via the "branch" option below)
+name: Push dist
+
+on:
+  push:
+    branches:
+      - main
+      - master
+
+jobs:
+  push-dist:
+    name: Push dist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Node
+        uses: actions/setup-node@v3
+        with:
+          cache: 'yarn'
+      - name: Install Dependencies
+        run: yarn install --frozen-lockfile
+      - uses: kategengler/put-built-npm-package-contents-on-branch@v1.0.0
+        with:
+          branch: dist
+          token: ${{ secrets.GITHUB_TOKEN }}
+          working-directory: my-addon 

--- a/tests/smoke-tests/defaults.test.ts
+++ b/tests/smoke-tests/defaults.test.ts
@@ -6,6 +6,7 @@ import {
   AddonHelper,
   assertGeneratedCorrectly,
   dirContents,
+  matchesFixture,
   SUPPORTED_PACKAGE_MANAGERS,
 } from '../helpers.js';
 
@@ -36,6 +37,8 @@ for (let packageManager of SUPPORTED_PACKAGE_MANAGERS) {
           expect(await fse.pathExists(yarn), 'yarn.lock does not exist').toBe(false);
           expect(await fse.pathExists(pnpm), 'pnpm-lock.yaml does not exist').toBe(false);
 
+          await matchesFixture('.github/workflows/push-dist.yml', { cwd: helper.projectRoot });
+
           break;
         }
         case 'yarn': {
@@ -43,12 +46,22 @@ for (let packageManager of SUPPORTED_PACKAGE_MANAGERS) {
           expect(await fse.pathExists(npm), 'package-lock.json does not exist').toBe(false);
           expect(await fse.pathExists(pnpm), 'pnpm-lock.yaml does not exist').toBe(false);
 
+          await matchesFixture('.github/workflows/push-dist.yml', {
+            cwd: helper.projectRoot,
+            scenario: 'yarn',
+          });
+
           break;
         }
         case 'pnpm': {
           expect(await fse.pathExists(pnpm), 'for pnpm: pnpm-lock.yaml exists').toBe(true);
           expect(await fse.pathExists(npm), 'package-lock.json does not exist').toBe(false);
           expect(await fse.pathExists(yarn), 'yarn.lock does not exist').toBe(false);
+
+          await matchesFixture('.github/workflows/push-dist.yml', {
+            cwd: helper.projectRoot,
+            scenario: 'pnpm',
+          });
 
           break;
         }
@@ -65,7 +78,7 @@ for (let packageManager of SUPPORTED_PACKAGE_MANAGERS) {
     });
 
     it('was generated correctly', async () => {
-      assertGeneratedCorrectly({ projectRoot: helper.projectRoot });
+      await assertGeneratedCorrectly({ projectRoot: helper.projectRoot });
     });
 
     // Tests are additive, so when running them in order, we want to check linting


### PR DESCRIPTION
Resolves #143
Requires: https://github.com/embroider-build/addon-blueprint/pull/151

Because v2 addons need to be built,
we can't easily point package.json files at the git repo for easy cross-repo testing.

This push-dist workflow brings back that capability by placing the compiled assets on a "dist" branch
(configurable via the "branch" option)



