### PR TITLE
Add a basic smoke test for a non-empty addon

### DIFF
--- a/tests/fixtures/components/template-only.hbs
+++ b/tests/fixtures/components/template-only.hbs
@@ -1,0 +1,3 @@
+<div data-test-template-only-component>Hi there from a template only component</div>
+
+{{outlet}}

--- a/tests/fixtures/tests/integration/components/template-only-test.js
+++ b/tests/fixtures/tests/integration/components/template-only-test.js
@@ -1,0 +1,23 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'test-app/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | template-only', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    await render(hbs`<TemplateOnly />`);
+
+    assert.dom(this.element).hasText('Hi there from a template only component');
+
+    // Template block usage:
+    await render(hbs`
+      <TemplateOnly>
+        template block text
+      </TemplateOnly>
+    `);
+
+    assert.dom(this.element).hasText('template block text');
+  });
+});

--- a/tests/smoke-tests/defaults.test.ts
+++ b/tests/smoke-tests/defaults.test.ts
@@ -82,7 +82,7 @@ for (let packageManager of SUPPORTED_PACKAGE_MANAGERS) {
       assertGeneratedCorrectly({ projectRoot: cwd });
     });
 
-    it('builds the addon', async () => {
+    it('builds the addon and runs tests', async () => {
       let { exitCode } = await runScript({ cwd, script: 'build', packageManager });
 
       expect(exitCode).toEqual(0);
@@ -90,12 +90,10 @@ for (let packageManager of SUPPORTED_PACKAGE_MANAGERS) {
       let contents = await dirContents(distDir);
 
       expect(contents).to.deep.equal(['index.js', 'index.js.map']);
-    });
 
-    it('runs tests', async () => {
-      let { exitCode } = await runScript({ cwd, script: 'test', packageManager });
+      let { exitCode: testExitCode } = await runScript({ cwd, script: 'test', packageManager });
 
-      expect(exitCode).toEqual(0);
+      expect(testExitCode).toEqual(0);
     });
 
     it('lints all pass', async () => {


### PR DESCRIPTION
We can expand on this as we go but this shows the issue I had been mentioning before that template-only components are not being generated correctly 👍 