### PR TITLE
Start testing component compilation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,8 @@ jobs:
         # so we could be sure we don't miss anything
         # and then generate this list from a previous C.I. job
         slow-test:
+          - components
+
           - defaults with npm
           - defaults with yarn
           - defaults with pnpm

--- a/tests/.prettierignore
+++ b/tests/.prettierignore
@@ -1,0 +1,3 @@
+# Editors may run prettier per-workspace, which would ignore 
+# the top-level workspaces' prettier config.
+fixtures/

--- a/tests/build-tests/components.test.ts
+++ b/tests/build-tests/components.test.ts
@@ -1,0 +1,106 @@
+import { execa } from 'execa';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, it } from 'vitest';
+
+import { AddonFixtureHelper } from '../fixture-helper.js';
+import { createAddon, createTmp, install } from '../utils.js';
+
+let packageManager = 'pnpm';
+
+describe('components (build)', () => {
+  describe('co-located JS', () => {
+    let cwd = '';
+    let tmpDir = '';
+    let addonOnlyJS: AddonFixtureHelper;
+
+    beforeEach(async () => {
+      tmpDir = await createTmp();
+
+      console.debug(`Debug test repo at ${tmpDir}`);
+
+      let { name } = await createAddon({
+        args: [`--pnpm=true`, '--addon-only'],
+        options: { cwd: tmpDir },
+      });
+
+      cwd = path.join(tmpDir, name);
+
+      addonOnlyJS = new AddonFixtureHelper({
+        cwd,
+        packageManager: 'pnpm',
+        scenario: 'addon-only-js',
+      });
+
+      await install({ cwd, packageManager, skipPrepare: true });
+
+      // NOTE: This isn't needed to make the tests pass atm, but it would be
+      // required when consumers try to use these compiled components
+      await execa('pnpm', ['add', '--save-peer', '@glimmer/component'], { cwd });
+    });
+
+    afterEach(async () => {
+      fs.rm(tmpDir, { recursive: true, force: true });
+    });
+
+    it('generates correct files with no template', async () => {
+      await addonOnlyJS.use('src/components/no-template.js');
+      await addonOnlyJS.build();
+      await addonOnlyJS.matches('dist/components/no-template.js');
+    });
+
+    it('generates correct files with a template', async () => {
+      await addonOnlyJS.use('src/components/co-located.js');
+      await addonOnlyJS.use('src/components/co-located.hbs');
+      await addonOnlyJS.build();
+      await addonOnlyJS.matches('dist/components/co-located.js');
+    });
+  });
+
+  describe('co-located TS', () => {
+    let cwd = '';
+    let tmpDir = '';
+    let addonOnlyTS: AddonFixtureHelper;
+
+    beforeEach(async () => {
+      tmpDir = await createTmp();
+
+      console.debug(`Debug test repo at ${tmpDir}`);
+
+      let { name } = await createAddon({
+        args: [`--pnpm=true`, '--addon-only', '--typescript'],
+        options: { cwd: tmpDir },
+      });
+
+      cwd = path.join(tmpDir, name);
+
+      addonOnlyTS = new AddonFixtureHelper({
+        cwd,
+        packageManager: 'pnpm',
+        scenario: 'addon-only-ts',
+      });
+
+      await install({ cwd, packageManager, skipPrepare: true });
+      await execa('pnpm', ['add', '--save-peer', '@glimmer/component'], { cwd });
+    });
+
+    afterEach(async () => {
+      fs.rm(tmpDir, { recursive: true, force: true });
+    });
+
+    it('generates correct files with no template', async () => {
+      await addonOnlyTS.use('src/components/no-template.ts');
+      await addonOnlyTS.build();
+      await addonOnlyTS.matches('dist/components/no-template.js');
+      await addonOnlyTS.matches('declarations/components/no-template.d.ts');
+    });
+
+    it('generates correct files with a template', async () => {
+      await addonOnlyTS.use('src/components/co-located.ts');
+      await addonOnlyTS.use('src/components/co-located.hbs');
+      await addonOnlyTS.build();
+      await addonOnlyTS.matches('dist/components/co-located.js');
+      await addonOnlyTS.matches('declarations/components/co-located.d.ts');
+    });
+  });
+});

--- a/tests/fixture-helper.ts
+++ b/tests/fixture-helper.ts
@@ -1,0 +1,30 @@
+import { matchesFixture } from './assertions.js';
+import { copyFixture, runScript } from './utils.js';
+
+export class AddonFixtureHelper {
+  #cwd: string;
+  #scenario: string;
+  #packageManager: 'npm' | 'pnpm' | 'yarn';
+
+  constructor(options: {
+    cwd: string;
+    scenario?: string;
+    packageManager: 'pnpm' | 'npm' | 'yarn';
+  }) {
+    this.#cwd = options.cwd;
+    this.#scenario = options.scenario || 'default';
+    this.#packageManager = options.packageManager;
+  }
+
+  async use(file: string) {
+    await copyFixture(file, { scenario: this.#scenario, cwd: this.#cwd });
+  }
+
+  async build() {
+    await runScript({ cwd: this.#cwd, script: 'build', packageManager: this.#packageManager });
+  }
+
+  async matches(outputFile: string) {
+    await matchesFixture(outputFile, { scenario: this.#scenario, cwd: this.#cwd });
+  }
+}

--- a/tests/fixtures/addon-only-js/dist/components/co-located.js
+++ b/tests/fixtures/addon-only-js/dist/components/co-located.js
@@ -1,0 +1,13 @@
+import { precompileTemplate } from '@ember/template-compilation';
+import Component from '@glimmer/component';
+
+precompileTemplate("{{this.someGetter}}\n");
+
+class CoLocated extends Component {
+  get someGetter() {
+    return 'someGetter';
+  }
+}
+
+export { CoLocated };
+//# sourceMappingURL=co-located.js.map

--- a/tests/fixtures/addon-only-js/dist/components/no-template.js
+++ b/tests/fixtures/addon-only-js/dist/components/no-template.js
@@ -1,0 +1,10 @@
+import Component from '@glimmer/component';
+
+class NoTemplate extends Component {
+  get someGetter() {
+    return 'someGetter';
+  }
+}
+
+export { NoTemplate };
+//# sourceMappingURL=no-template.js.map

--- a/tests/fixtures/addon-only-js/src/components/co-located.hbs
+++ b/tests/fixtures/addon-only-js/src/components/co-located.hbs
@@ -1,0 +1,1 @@
+{{this.someGetter}}

--- a/tests/fixtures/addon-only-js/src/components/co-located.js
+++ b/tests/fixtures/addon-only-js/src/components/co-located.js
@@ -1,0 +1,7 @@
+import Component from '@glimmer/component';
+
+export class CoLocated extends Component {
+  get someGetter() {
+    return 'someGetter';
+  }
+}

--- a/tests/fixtures/addon-only-js/src/components/no-template.js
+++ b/tests/fixtures/addon-only-js/src/components/no-template.js
@@ -1,0 +1,7 @@
+import Component from '@glimmer/component';
+
+export class NoTemplate extends Component {
+  get someGetter() {
+    return 'someGetter';
+  }
+}

--- a/tests/fixtures/addon-only-ts/declarations/components/co-located.d.ts
+++ b/tests/fixtures/addon-only-ts/declarations/components/co-located.d.ts
@@ -1,0 +1,12 @@
+import Component from '@glimmer/component';
+interface Signature {
+    Args: {};
+    Blocks: {
+        default: [];
+    };
+}
+export default class CoLocated extends Component<Signature> {
+    get someGetter(): string;
+}
+export {};
+//# sourceMappingURL=co-located.d.ts.map

--- a/tests/fixtures/addon-only-ts/declarations/components/no-template.d.ts
+++ b/tests/fixtures/addon-only-ts/declarations/components/no-template.d.ts
@@ -1,0 +1,10 @@
+import Component from '@glimmer/component';
+interface Signature {
+    Args: {};
+    Blocks: {};
+}
+export declare class NoTemplate extends Component<Signature> {
+    get someGetter(): string;
+}
+export {};
+//# sourceMappingURL=no-template.d.ts.map

--- a/tests/fixtures/addon-only-ts/dist/components/co-located.js
+++ b/tests/fixtures/addon-only-ts/dist/components/co-located.js
@@ -1,0 +1,15 @@
+import { setComponentTemplate } from '@ember/component';
+import { precompileTemplate } from '@ember/template-compilation';
+import Component from '@glimmer/component';
+
+var TEMPLATE = precompileTemplate("{{this.someGetter}}\n\n{{yield}}\n");
+
+class CoLocated extends Component {
+  get someGetter() {
+    return 'someGetter';
+  }
+}
+setComponentTemplate(TEMPLATE, CoLocated);
+
+export { CoLocated as default };
+//# sourceMappingURL=co-located.js.map

--- a/tests/fixtures/addon-only-ts/dist/components/no-template.js
+++ b/tests/fixtures/addon-only-ts/dist/components/no-template.js
@@ -1,0 +1,10 @@
+import Component from '@glimmer/component';
+
+class NoTemplate extends Component {
+  get someGetter() {
+    return 'someGetter';
+  }
+}
+
+export { NoTemplate };
+//# sourceMappingURL=no-template.js.map

--- a/tests/fixtures/addon-only-ts/src/components/co-located.hbs
+++ b/tests/fixtures/addon-only-ts/src/components/co-located.hbs
@@ -1,0 +1,3 @@
+{{this.someGetter}}
+
+{{yield}}

--- a/tests/fixtures/addon-only-ts/src/components/co-located.ts
+++ b/tests/fixtures/addon-only-ts/src/components/co-located.ts
@@ -1,0 +1,12 @@
+import Component from '@glimmer/component';
+
+interface Signature {
+  Args: {},
+  Blocks: { default: [] } 
+}
+
+export default class CoLocated extends Component<Signature> {
+  get someGetter() {
+    return 'someGetter';
+  }
+}

--- a/tests/fixtures/addon-only-ts/src/components/no-template.ts
+++ b/tests/fixtures/addon-only-ts/src/components/no-template.ts
@@ -1,0 +1,12 @@
+import Component from '@glimmer/component';
+
+interface Signature {
+  Args: {},
+  Blocks: {} 
+}
+
+export class NoTemplate extends Component<Signature> {
+  get someGetter() {
+    return 'someGetter';
+  }
+}

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -7,5 +7,6 @@
 
     // Vite's internal types aren't relevant to us
     "skipLibCheck": true
-  }
+  },
+  "exclude": ["fixtures/"]
 }

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -13,6 +13,43 @@ const fixturesPath = path.join(__dirname, 'fixtures');
 
 export const SUPPORTED_PACKAGE_MANAGERS = ['npm', 'yarn', 'pnpm'] as const;
 
+export async function copyFixture(
+  /**
+   * Which file within the fixture-set / scenario to copy
+   */
+  newFile: string,
+  options?: {
+    /**
+     * Which fixture set to use
+     */
+    scenario?: string;
+    /**
+     * By default, the file used will be the same as the testFilePath, but
+     * in the fixtures directory under the (maybe) specified scenario.
+     * this can be overridden, if needed.
+     * (like if you're testFilePath is deep with in an existing monorepo, and wouldn't
+     *   inherently match our default-project structure used in the fixtures)
+     */
+    file?: string;
+    /**
+     * The working directory to use for the relative paths. Defaults to process.cwd() (node default)
+     */
+    cwd?: string;
+  }
+) {
+  let scenario = options?.scenario ?? 'default';
+  let fixtureFile = options?.file ?? newFile;
+
+  if (options?.cwd) {
+    newFile = path.join(options.cwd, newFile);
+  }
+
+  let fixtureContents = await fixture(fixtureFile, { scenario });
+
+  await fse.mkdir(path.dirname(newFile), { recursive: true });
+  await fs.writeFile(newFile, fixtureContents);
+}
+
 export async function fixture(
   /**
    * Which file within in the fixture-set / scenario to read


### PR DESCRIPTION
Builds on top of: https://github.com/embroider-build/addon-blueprint/pull/151

tests that various component scenarios are generated correctly

(basically snapshot testing with files)


This will allow us to feel more comfortable with switching up the rollup config without worrying about breaking stuff in the future.


In an effort to keep PRs small, and avoid overwhelming reviewers, I've kept the number of tests added to a small amount, and will add more in follow up PRs.

In particular, we need:
- template-only components
- private / non-re-exported components
- non-entrypoint files in general
- keepAssets behavior
- gjs / gts, even though we don't generate support for this by default
- and more!