### PR TITLE
Remove node resolve

### DIFF
--- a/files/__addonLocation__/package.json
+++ b/files/__addonLocation__/package.json
@@ -67,7 +67,6 @@
     "@typescript-eslint/eslint-plugin": "^5.30.5",
     "@typescript-eslint/parser": "^5.30.5",<% } %>
     "@rollup/plugin-babel": "^6.0.3",
-    "@rollup/plugin-node-resolve": "^15.1.0",
     "concurrently": "^8.0.1",
     "ember-template-lint": "^5.7.3",
     "eslint": "^8.33.0",

--- a/files/__addonLocation__/rollup.config.mjs
+++ b/files/__addonLocation__/rollup.config.mjs
@@ -1,5 +1,4 @@
 import { babel } from '@rollup/plugin-babel';
-import { nodeResolve } from '@rollup/plugin-node-resolve';
 <% if (!isExistingMonorepo) { %>import copy from 'rollup-plugin-copy';
 <% } %>import { Addon } from '@embroider/addon-dev/rollup';
 
@@ -41,9 +40,6 @@ export default {
       extensions,
       babelHelpers: 'bundled',
     }),
-
-    // Allows rollup to resolve imports of files with the specified extensions
-    nodeResolve({ extensions }),
 
     // Ensure that standalone .hbs files are properly integrated as Javascript.
     addon.hbs(),


### PR DESCRIPTION
I had thought that this plugin was needed for TS (and other extensions) to resolve itself -- but it's maybe possible that when I came across that tha either:
- I also typo'd the extensions list to the babel plugin
- I forgot (somehow) to change the babel extensions
- Or there was a bug in babel's rollup plugin at the time.

The first and second are way more likely, ofc.

With this change, we can create js, template-only, and ts components and have the template-contents compiled correctly:

I will be following up with smoke tests to automate these checks for us.

Input: 
![image](https://github.com/embroider-build/addon-blueprint/assets/199018/a8845a1d-267a-475e-bc34-e78046c0c050)

Output:
![image](https://github.com/embroider-build/addon-blueprint/assets/199018/026a6c66-1a0d-4881-8cfc-b5bbee630b94)
