### PR TITLE
Component compilation tests

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: false
-  excludeLinksFromLockfile: false
-
 overrides:
   '@octokit/core': ^4.0.0
 
@@ -573,7 +569,7 @@ packages:
       debug: 4.3.4
       espree: 9.3.2
       globals: 13.16.0
-      ignore: 5.2.0
+      ignore: 5.2.4
       import-fresh: 3.3.0
       js-yaml: 4.1.0
       minimatch: 3.1.2
@@ -641,7 +637,7 @@ packages:
     dependencies:
       '@jridgewell/set-array': 1.1.2
       '@jridgewell/sourcemap-codec': 1.4.14
-      '@jridgewell/trace-mapping': 0.3.14
+      '@jridgewell/trace-mapping': 0.3.18
     dev: true
 
   /@jridgewell/resolve-uri@3.1.0:
@@ -1130,7 +1126,7 @@ packages:
       debug: 4.3.4
       eslint: 7.32.0
       functional-red-black-tree: 1.0.1
-      ignore: 5.2.0
+      ignore: 5.2.4
       regexpp: 3.2.0
       semver: 7.3.8
       tsutils: 3.21.0(typescript@4.7.4)
@@ -3779,7 +3775,7 @@ packages:
       eslint: 7.32.0
       eslint-plugin-es: 3.0.1(eslint@7.32.0)
       eslint-utils: 2.1.0
-      ignore: 5.2.0
+      ignore: 5.2.4
       minimatch: 3.1.2
       resolve: 1.22.1
       semver: 6.3.0
@@ -4234,8 +4230,8 @@ packages:
     resolution: {integrity: sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==}
     dev: true
 
-  /fast-glob@3.2.11:
-    resolution: {integrity: sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==}
+  /fast-glob@3.3.0:
+    resolution: {integrity: sha512-ChDuvbOypPuNjO8yIDf36x7BlZX1smcUMTTcyoIjycexOxd6DFsKsg21qVBzEmr3G7fUKIRy2/psii+CIUt7FA==}
     engines: {node: '>=8.6.0'}
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -4911,9 +4907,9 @@ packages:
       '@types/glob': 7.2.0
       array-union: 2.1.0
       dir-glob: 3.0.1
-      fast-glob: 3.2.11
+      fast-glob: 3.3.0
       glob: 7.2.3
-      ignore: 5.2.0
+      ignore: 5.2.4
       merge2: 1.4.1
       slash: 3.0.0
 
@@ -4923,8 +4919,8 @@ packages:
     dependencies:
       array-union: 2.1.0
       dir-glob: 3.0.1
-      fast-glob: 3.2.11
-      ignore: 5.2.0
+      fast-glob: 3.3.0
+      ignore: 5.2.4
       merge2: 1.4.1
       slash: 3.0.0
     dev: true
@@ -4934,8 +4930,8 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dependencies:
       dir-glob: 3.0.1
-      fast-glob: 3.2.11
-      ignore: 5.2.0
+      fast-glob: 3.3.0
+      ignore: 5.2.4
       merge2: 1.4.1
       slash: 4.0.0
     dev: true
@@ -5324,6 +5320,11 @@ packages:
 
   /ignore@5.2.0:
     resolution: {integrity: sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==}
+    engines: {node: '>= 4'}
+    dev: true
+
+  /ignore@5.2.4:
+    resolution: {integrity: sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==}
     engines: {node: '>= 4'}
 
   /import-fresh@3.3.0:
@@ -10084,3 +10085,7 @@ packages:
       - walrus
       - whiskers
     dev: true
+
+settings:
+  autoInstallPeers: false
+  excludeLinksFromLockfile: false

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -1,0 +1,6 @@
+This way of doing fixtures allows us to set up multiple scenarios for different inputs to our tests.
+
+```
+./fixtures/${scenarioName}/ ... files and folders for the scenario ...
+```
+

--- a/tests/fixtures/default/my-addon/src/components/co-located.hbs
+++ b/tests/fixtures/default/my-addon/src/components/co-located.hbs
@@ -1,0 +1,1 @@
+Hello, {{this.whereAmI}}

--- a/tests/fixtures/default/my-addon/src/components/co-located.js
+++ b/tests/fixtures/default/my-addon/src/components/co-located.js
@@ -1,0 +1,5 @@
+import Component from '@glimmer/component';
+
+export default class CoLocated extends Component {
+  whereAmI = 'from a co-located component';
+}

--- a/tests/fixtures/default/my-addon/src/components/template-only.hbs
+++ b/tests/fixtures/default/my-addon/src/components/template-only.hbs
@@ -1,0 +1,1 @@
+Hello from a template-only component

--- a/tests/fixtures/default/test-app/tests/rendering/co-located-test.js
+++ b/tests/fixtures/default/test-app/tests/rendering/co-located-test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Rendering | co-located', function(hooks) {
   setupRenderingTest(hooks);

--- a/tests/fixtures/default/test-app/tests/rendering/co-located-test.js
+++ b/tests/fixtures/default/test-app/tests/rendering/co-located-test.js
@@ -1,0 +1,13 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+
+module('Rendering | co-located', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    await render(hbs`<CoLocated />`);
+
+    assert.dom().hasText('Hello, from a co-located component');
+  })
+});

--- a/tests/fixtures/default/test-app/tests/rendering/template-only-test.js
+++ b/tests/fixtures/default/test-app/tests/rendering/template-only-test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Rendering | template-only', function(hooks) {
   setupRenderingTest(hooks);

--- a/tests/fixtures/default/test-app/tests/rendering/template-only-test.js
+++ b/tests/fixtures/default/test-app/tests/rendering/template-only-test.js
@@ -1,0 +1,13 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+
+module('Rendering | template-only', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    await render(hbs`<TemplateOnly />`);
+
+    assert.dom().hasText('Hello from a template-only component');
+  })
+});

--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -74,8 +74,32 @@ export async function copyFixture(
     newFile = path.join(options.cwd, newFile);
   }
 
+  let fullFixturePath = path.join(fixturesPath, scenario, fixtureFile);
+  let exists = await fse.pathExists(fullFixturePath);
+
+  assert(
+    exists,
+    `Fixture path '${fixtureFile}' does not exist. To make this work, place a new file/folder '${fixtureFile}' in the 'tests/fixtures/${scenario}' directory. Checked the absolute path: '${fullFixturePath}'.`
+  );
+
+  if (await isDirectory(fullFixturePath)) {
+    await fse.copy(fullFixturePath, newFile);
+
+    return;
+  }
+
   let fixtureContents = await readFixture(fixtureFile, { scenario });
 
   await fse.mkdir(path.dirname(newFile), { recursive: true });
   await fs.writeFile(newFile, fixtureContents);
+}
+
+async function isDirectory(maybePath: string) {
+  try {
+    const stats = await fs.stat(maybePath);
+
+    return stats.isDirectory();
+  } catch {
+    return false;
+  }
 }

--- a/tests/helpers/meta-helpers.ts
+++ b/tests/helpers/meta-helpers.ts
@@ -59,7 +59,7 @@ export class AddonHelper {
     }
 
     let { name } = await createAddon({
-      args: this.#args,
+      args,
       options: { cwd: this.#tmpDir },
     });
 
@@ -93,11 +93,13 @@ export class AddonHelper {
     await fs.rm(this.#tmpDir, { recursive: true, force: true });
   }
 
-  async installDeps() {
+  async installDeps(options?: { skipPrepare: boolean }) {
+    let skipPrepare = options?.skipPrepare ?? true;
+
     await install({
       cwd: this.projectRoot,
       packageManager: this.#packageManager,
-      skipPrepare: true,
+      skipPrepare,
     });
   }
 

--- a/tests/helpers/utils.ts
+++ b/tests/helpers/utils.ts
@@ -5,6 +5,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+const DEBUG = process.env.DEBUG === 'true';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // repo-root
@@ -128,11 +129,18 @@ export async function createAddon({
   args?: string[];
   options?: Options;
 }) {
-  let result = await execa(
-    'ember',
-    ['addon', name, '-b', blueprintPath, '--skip-npm', '--skip-git', ...args],
-    { ...options, env: { ...options.env, EMBER_CLI_PNPM: 'true' }, preferLocal: true }
-  );
+  let emberCliArgs = ['addon', name, '-b', blueprintPath, '--skip-npm', '--skip-git', ...args];
+
+  if (DEBUG) {
+    console.debug(`Running ember-cli in ${options.cwd}`);
+    console.debug(`\tember ${emberCliArgs.join(' ')}`);
+  }
+
+  let result = await execa('ember', emberCliArgs, {
+    ...options,
+    env: { ...options.env, EMBER_CLI_PNPM: 'true' },
+    preferLocal: true,
+  });
 
   // Light work-around for an upstream `@babel/core` peer issue
   if (typeof options.cwd === 'string') {

--- a/tests/smoke-tests/--addon-only.test.ts
+++ b/tests/smoke-tests/--addon-only.test.ts
@@ -17,8 +17,10 @@ describe('--addon-only', () => {
   });
 
   it('is not a monorepo', async () => {
-    let hasPnpmWorkspace = await fse.pathExists(path.join(helper.cwd, 'pnpm-workspace.yaml'));
-    let packageJson = await fse.readJson(path.join(helper.cwd, 'package.json'));
+    let hasPnpmWorkspace = await fse.pathExists(
+      path.join(helper.projectRoot, 'pnpm-workspace.yaml')
+    );
+    let packageJson = await fse.readJson(path.join(helper.projectRoot, 'package.json'));
 
     expect(hasPnpmWorkspace).toBe(false);
     // Pnpm doesn't use this field, but it's good that it doesn't exist.


### PR DESCRIPTION
tests that various component scenarios are generated correctly by running tests in the test-app that use those components.


This will allow us to feel more comfortable with switching up the rollup config without worrying about breaking stuff in the future.


In an effort to keep PRs small, and avoid overwhelming reviewers, I've kept the number of tests added to a small amount, and will add more in follow up PRs.

In particular, we need:
- typescript
- private / non-re-exported components
- non-entrypoint files in general
- keepAssets behavior
- gjs / gts, even though we don't generate support for this by default
- and more!