### PR TITLE
Add typescript component building / testing tests

### DIFF
--- a/tests/fixtures/typescript/my-addon/src/components/co-located-ts.hbs
+++ b/tests/fixtures/typescript/my-addon/src/components/co-located-ts.hbs
@@ -1,0 +1,3 @@
+Hello,
+{{this.whereAmI}}
+(in TypeScript)

--- a/tests/fixtures/typescript/my-addon/src/components/co-located-ts.ts
+++ b/tests/fixtures/typescript/my-addon/src/components/co-located-ts.ts
@@ -1,0 +1,5 @@
+import Component from '@glimmer/component';
+
+export default class CoLocatedTs extends Component {
+  whereAmI = 'from a co-located TS component';
+}

--- a/tests/fixtures/typescript/my-addon/src/components/co-located.hbs
+++ b/tests/fixtures/typescript/my-addon/src/components/co-located.hbs
@@ -1,0 +1,1 @@
+Hello, {{this.whereAmI}}

--- a/tests/fixtures/typescript/my-addon/src/components/co-located.js
+++ b/tests/fixtures/typescript/my-addon/src/components/co-located.js
@@ -1,0 +1,5 @@
+import Component from '@glimmer/component';
+
+export default class CoLocated extends Component {
+  whereAmI = 'from a co-located component';
+}

--- a/tests/fixtures/typescript/my-addon/src/components/template-only.hbs
+++ b/tests/fixtures/typescript/my-addon/src/components/template-only.hbs
@@ -1,0 +1,1 @@
+Hello from a template-only component

--- a/tests/fixtures/typescript/test-app/tests/rendering/co-located-test.ts
+++ b/tests/fixtures/typescript/test-app/tests/rendering/co-located-test.ts
@@ -1,0 +1,20 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Rendering | co-located', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders a JS component', async function (assert) {
+    await render(hbs`<CoLocated />`);
+
+    assert.dom().hasText('Hello, from a co-located component');
+  });
+
+  test('it renders a TS component', async function (assert) {
+    await render(hbs`<CoLocatedTs />`);
+
+    assert.dom().containsText('Hello, from a co-located TS component (in TypeScript)');
+  });
+});

--- a/tests/fixtures/typescript/test-app/tests/rendering/template-only-test.ts
+++ b/tests/fixtures/typescript/test-app/tests/rendering/template-only-test.ts
@@ -1,0 +1,14 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Rendering | template-only', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    await render(hbs`<TemplateOnly />`);
+
+    assert.dom().hasText('Hello from a template-only component');
+  })
+});

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -7,5 +7,6 @@
 
     // Vite's internal types aren't relevant to us
     "skipLibCheck": true
-  }
+  },
+  "exclude": ["./fixtures/**/*"]
 }


### PR DESCRIPTION
Followup to: https://github.com/embroider-build/addon-blueprint/pull/156

Where we test that, when using `--typescript`, we can:
- build and use a template-only component
- build and use a js co-located component
- build and use a ts co-located component