### PR TITLE
Separate lint tests

### DIFF
--- a/src/root-package-json.js
+++ b/src/root-package-json.js
@@ -55,6 +55,7 @@ let scripts = {
       'start:addon': `npm start --workspace ${addonName} -- --no-watch.clearScreen`,
       'start:test-app': `npm start --workspace ${testAppName}`,
       test: 'npm run test --workspaces --if-present',
+      'test:ember': 'npm run test:ember --workspaces --if-present',
     };
   },
 
@@ -77,6 +78,8 @@ let scripts = {
       'start:addon': `yarn workspace ${addonName} run start`,
       'start:test-app': `yarn workspace ${testAppName} run start`,
       test: 'yarn workspaces run test',
+      // yarn doesn't support --skip-missing style for workspaces so we have to specify the test app workspace here :(
+      'test:ember': `yarn workspace ${testAppName} run test:ember`,
     };
   },
 
@@ -118,6 +121,7 @@ let scripts = {
        *  (this is a consequence of enforced strict peers)
        */
       test: "pnpm --filter '*' test",
+      'test:ember': "pnpm --filter '*' test:ember",
     };
   },
 };

--- a/tests/smoke-tests/defaults.test.ts
+++ b/tests/smoke-tests/defaults.test.ts
@@ -83,8 +83,17 @@ for (let packageManager of SUPPORTED_PACKAGE_MANAGERS) {
 
     // Tests are additive, so when running them in order, we want to check linting
     // before we add files from fixtures
-    it('lints all pass', async () => {
+    it('lints with no fixtures all pass', async () => {
       let { exitCode } = await helper.run('lint');
+
+      expect(exitCode).toEqual(0);
+    });
+
+    it('lint with fixtures pass', async () => {
+      await helper.fixtures.use('./my-addon/src/components');
+      await helper.fixtures.use('./test-app/tests');
+
+      let { exitCode } = await helper.run('lint:fix');
 
       expect(exitCode).toEqual(0);
     });

--- a/tests/smoke-tests/defaults.test.ts
+++ b/tests/smoke-tests/defaults.test.ts
@@ -102,7 +102,7 @@ for (let packageManager of SUPPORTED_PACKAGE_MANAGERS) {
 
       expect(contents).to.deep.equal(['_app_', 'components', 'index.js', 'index.js.map']);
 
-      let testResult = await helper.run('test');
+      let testResult = await helper.run('test:ember');
 
       expect(testResult.exitCode).toEqual(0);
       expect(testResult.stdout).to.include('# tests 3');

--- a/tests/smoke-tests/defaults.test.ts
+++ b/tests/smoke-tests/defaults.test.ts
@@ -93,8 +93,6 @@ for (let packageManager of SUPPORTED_PACKAGE_MANAGERS) {
       // Copy over fixtures
       await helper.fixtures.use('./my-addon/src/components');
       await helper.fixtures.use('./test-app/tests');
-      // Sync fixture with project's lint / formatting configuration
-      await helper.run('lint:fix');
 
       let buildResult = await helper.build();
 


### PR DESCRIPTION
This PR cleans up how our smoke tests run lint tests and means that if there is a failure in lint it won't show up as a failure in the `build and test` test 👍 

This has been extracted from #159 to make that PR a bit smaller/simpler