### PR TITLE
update concurrently version in top-level monorepo

### DIFF
--- a/files/package.json
+++ b/files/package.json
@@ -5,7 +5,7 @@
   "author": "",
   "scripts": {},
   "devDependencies": {
-    "concurrently": "^7.2.1",
+    "concurrently": "^8.2.0",
     "prettier": "^2.5.1"
   },
   "workspaces": [


### PR DESCRIPTION
I was having strange errors in #159 complaining about `chalk` in the workspace 🤔 

It turns out it's just a really really really poor error message that yarn@1 is doing when there is some sort of monorepo conflict of versions. The test-app uses the newest version of `concurrently` and I'm assuming because `chalk` is a dependency of that it wasn't able to install correctly 🤷  updating the top-level monorepo to match the test-app fixes it 🎉 