### PR TITLE
Make sure the `node_modules` folder is ignored by Git

### DIFF
--- a/files/gitignore
+++ b/files/gitignore
@@ -1,5 +1,8 @@
 # See https://help.github.com/ignore-files/ for more about ignoring files.
 
+# dependencies
+node_modules/
+
 # misc
 .env*
 .pnp*


### PR DESCRIPTION
I _think_ this was removed by accident over in https://github.com/embroider-build/addon-blueprint/pull/167?