### PR TITLE
Make sure `node-version` is always specified in the GitHub CI file

### DIFF
--- a/tests/fixtures/default/.github/workflows/ci.yml
+++ b/tests/fixtures/default/.github/workflows/ci.yml
@@ -18,16 +18,16 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: <%= pnpm ? 'wyvox/action-setup-pnpm@v2' : 'actions/setup-node@v3' %>
+      - uses: actions/setup-node@v3
         with:
-          node-version: 16<% if (!pnpm) { %>
-          cache: <%= yarn ? 'yarn' : 'npm' %>
+          node-version: 16
+          cache: npm
       - name: Install Dependencies
-        run: <%= yarn ? 'yarn install --frozen-lockfile' : 'npm ci' %><%}%>
+        run: npm ci
       - name: Lint
-        run: <%= pnpm ? 'pnpm' : yarn ? 'yarn' : 'npm run' %> lint
+        run: npm run lint
       - name: Run Tests
-        run: <%= pnpm ? 'pnpm' : yarn ? 'yarn' : 'npm run' %> test
+        run: npm run test
 
   floating:
     name: "Floating Dependencies"
@@ -35,14 +35,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: <%= pnpm ? 'wyvox/action-setup-pnpm@v2' : 'actions/setup-node@v3' %>
+      - uses: actions/setup-node@v3
         with:
-          node-version: 16<% if (!pnpm) { %>
-          cache: <%= yarn ? 'yarn' : 'npm' %>
+          node-version: 16
+          cache: npm
       - name: Install Dependencies
-        run: <%= yarn ? 'yarn install --frozen-lockfile' : 'npm ci' %><%}%>
+        run: npm ci
       - name: Run Tests
-        run: <%= pnpm ? 'pnpm' : yarn ? 'yarn' : 'npm run' %> test
+        run: npm run test
 
   try-scenarios:
     name: ${{ matrix.try-scenario }}
@@ -63,12 +63,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: <%= pnpm ? 'wyvox/action-setup-pnpm@v2' : 'actions/setup-node@v3' %>
+      - uses: actions/setup-node@v3
         with:
-          node-version: 16<% if (!pnpm) { %>
-          cache: <%= yarn ? 'yarn' : 'npm' %>
+          node-version: 16
+          cache: npm
       - name: Install Dependencies
-        run: <%= yarn ? 'yarn install --frozen-lockfile' : 'npm ci' %><%}%>
+        run: npm ci
       - name: Run Tests
         run: ./node_modules/.bin/ember try:one ${{ matrix.try-scenario }}
-        working-directory: <%= testAppInfo.location %>
+        working-directory: test-app

--- a/tests/fixtures/pnpm/.github/workflows/ci.yml
+++ b/tests/fixtures/pnpm/.github/workflows/ci.yml
@@ -1,0 +1,65 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request: {}
+
+concurrency:
+   group: ci-${{ github.head_ref || github.ref }}
+   cancel-in-progress: true
+
+jobs:
+  test:
+    name: "Tests"
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: wyvox/action-setup-pnpm@v2
+        with:
+          node-version: 16
+      - name: Lint
+        run: pnpm lint
+      - name: Run Tests
+        run: pnpm test
+
+  floating:
+    name: "Floating Dependencies"
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: wyvox/action-setup-pnpm@v2
+        with:
+          node-version: 16
+      - name: Run Tests
+        run: pnpm test
+
+  try-scenarios:
+    name: ${{ matrix.try-scenario }}
+    runs-on: ubuntu-latest
+    needs: 'test'
+
+    strategy:
+      fail-fast: false
+      matrix:
+        try-scenario:
+          - ember-lts-4.8
+          - ember-lts-4.12
+          - ember-release
+          - ember-beta
+          - ember-canary
+          - embroider-safe
+          - embroider-optimized
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: wyvox/action-setup-pnpm@v2
+        with:
+          node-version: 16
+      - name: Run Tests
+        run: ./node_modules/.bin/ember try:one ${{ matrix.try-scenario }}
+        working-directory: test-app

--- a/tests/fixtures/yarn/.github/workflows/ci.yml
+++ b/tests/fixtures/yarn/.github/workflows/ci.yml
@@ -18,16 +18,16 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: <%= pnpm ? 'wyvox/action-setup-pnpm@v2' : 'actions/setup-node@v3' %>
+      - uses: actions/setup-node@v3
         with:
-          node-version: 16<% if (!pnpm) { %>
-          cache: <%= yarn ? 'yarn' : 'npm' %>
+          node-version: 16
+          cache: yarn
       - name: Install Dependencies
-        run: <%= yarn ? 'yarn install --frozen-lockfile' : 'npm ci' %><%}%>
+        run: yarn install --frozen-lockfile
       - name: Lint
-        run: <%= pnpm ? 'pnpm' : yarn ? 'yarn' : 'npm run' %> lint
+        run: yarn lint
       - name: Run Tests
-        run: <%= pnpm ? 'pnpm' : yarn ? 'yarn' : 'npm run' %> test
+        run: yarn test
 
   floating:
     name: "Floating Dependencies"
@@ -35,14 +35,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: <%= pnpm ? 'wyvox/action-setup-pnpm@v2' : 'actions/setup-node@v3' %>
+      - uses: actions/setup-node@v3
         with:
-          node-version: 16<% if (!pnpm) { %>
-          cache: <%= yarn ? 'yarn' : 'npm' %>
+          node-version: 16
+          cache: yarn
       - name: Install Dependencies
-        run: <%= yarn ? 'yarn install --frozen-lockfile' : 'npm ci' %><%}%>
+        run: yarn install --frozen-lockfile
       - name: Run Tests
-        run: <%= pnpm ? 'pnpm' : yarn ? 'yarn' : 'npm run' %> test
+        run: yarn test
 
   try-scenarios:
     name: ${{ matrix.try-scenario }}
@@ -63,12 +63,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: <%= pnpm ? 'wyvox/action-setup-pnpm@v2' : 'actions/setup-node@v3' %>
+      - uses: actions/setup-node@v3
         with:
-          node-version: 16<% if (!pnpm) { %>
-          cache: <%= yarn ? 'yarn' : 'npm' %>
+          node-version: 16
+          cache: yarn
       - name: Install Dependencies
-        run: <%= yarn ? 'yarn install --frozen-lockfile' : 'npm ci' %><%}%>
+        run: yarn install --frozen-lockfile
       - name: Run Tests
         run: ./node_modules/.bin/ember try:one ${{ matrix.try-scenario }}
-        working-directory: <%= testAppInfo.location %>
+        working-directory: test-app

--- a/tests/smoke-tests/defaults.test.ts
+++ b/tests/smoke-tests/defaults.test.ts
@@ -37,6 +37,7 @@ for (let packageManager of SUPPORTED_PACKAGE_MANAGERS) {
           expect(await fse.pathExists(yarn), 'yarn.lock does not exist').toBe(false);
           expect(await fse.pathExists(pnpm), 'pnpm-lock.yaml does not exist').toBe(false);
 
+          await matchesFixture('.github/workflows/ci.yml', { cwd: helper.projectRoot });
           await matchesFixture('.github/workflows/push-dist.yml', { cwd: helper.projectRoot });
 
           break;
@@ -46,6 +47,10 @@ for (let packageManager of SUPPORTED_PACKAGE_MANAGERS) {
           expect(await fse.pathExists(npm), 'package-lock.json does not exist').toBe(false);
           expect(await fse.pathExists(pnpm), 'pnpm-lock.yaml does not exist').toBe(false);
 
+          await matchesFixture('.github/workflows/ci.yml', {
+            cwd: helper.projectRoot,
+            scenario: 'yarn',
+          });
           await matchesFixture('.github/workflows/push-dist.yml', {
             cwd: helper.projectRoot,
             scenario: 'yarn',
@@ -58,6 +63,10 @@ for (let packageManager of SUPPORTED_PACKAGE_MANAGERS) {
           expect(await fse.pathExists(npm), 'package-lock.json does not exist').toBe(false);
           expect(await fse.pathExists(yarn), 'yarn.lock does not exist').toBe(false);
 
+          await matchesFixture('.github/workflows/ci.yml', {
+            cwd: helper.projectRoot,
+            scenario: 'pnpm',
+          });
           await matchesFixture('.github/workflows/push-dist.yml', {
             cwd: helper.projectRoot,
             scenario: 'pnpm',


### PR DESCRIPTION
At the moment, when you generate a v2 addon using the `--pnpm` flag, no `node-version` is specified in the CI file. `wyvox/action-setup-pnpm` uses `actions/setup-node` internally.

The `actions/setup-node` docs mention the following:

> The node-version input is optional. If not supplied, the node version from PATH will be used. However, it is recommended to always specify Node.js version and don't rely on the system one.

So seems best to specify a version?

This way, a `node-version` is always specified in the CI file, regardless of the chosen package manager.

Results:

npm:

```yaml
    steps:
      - uses: actions/checkout@v3
      - uses: actions/setup-node@v3
        with:
          node-version: 16
          cache: npm
      - name: Install Dependencies
        run: npm ci
      - name: Run Tests
        run: npm run test
```

yarn:

```yaml
    steps:
      - uses: actions/checkout@v3
      - uses: actions/setup-node@v3
        with:
          node-version: 16
          cache: yarn
      - name: Install Dependencies
        run: yarn install --frozen-lockfile
      - name: Run Tests
        run: yarn test
```

pnpm:

```yaml
    steps:
      - uses: actions/checkout@v3
      - uses: wyvox/action-setup-pnpm@v2
        with:
          node-version: 16
      - name: Run Tests
        run: pnpm test
```