### PR TITLE
Add publint and are-the-type-wrong

### DIFF
--- a/files/__addonLocation__/package.json
+++ b/files/__addonLocation__/package.json
@@ -6,6 +6,7 @@
     "ember-addon"
   ],
   "repository": "",
+  "type": "module",
   "license": "MIT",
   "author": "",
   "files": [
@@ -25,7 +26,9 @@
     "lint:hbs:fix": "ember-template-lint . --fix --no-error-on-unmatched-pattern",
     "lint:js:fix": "eslint . --fix",<% if (typescript) { %>
     "lint:types": "glint",
-    "start": "concurrently 'npm:start:*'",
+    "lint:package": "publint",
+    <% if (typescript) { %>"lint:published-types": "attw --pack --exclude-entrypoints addon-main.js --ignore-rules cjs-resolves-to-esm",
+    <% } %>"start": "concurrently 'npm:start:*'",
     "start:js": "rollup --config --watch --no-watch.clearScreen",
     "start:types": "glint --declaration --watch",<% } else { %>
     "start": "rollup --config --watch",<% } %>
@@ -36,7 +39,8 @@
     "@embroider/addon-shim": "^1.0.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.17.0",
+    <% if (typescript) { %>"@arethetypeswrong/cli": "^0.7.1",
+    <% } %>"@babel/core": "^7.17.0",
     <% if (typescript) { %>"@babel/preset-typescript": "^7.18.6"<% } else { %>"@babel/eslint-parser": "^7.19.1"<% } %>,
     "@babel/plugin-proposal-class-properties": "^7.16.7",
     "@babel/plugin-proposal-decorators": "^7.20.13",
@@ -78,6 +82,7 @@
     "eslint-plugin-prettier": "^4.0.0",
     "prettier": "^2.5.1",
     "prettier-plugin-ember-template-tag": "^1.0.0",
+    "publint": "^0.2.0",
     "rollup": "^3.21.8"<% if (!isExistingMonorepo) { %>,
     "rollup-plugin-copy": "^3.4.0"<% } %><% if (typescript) { %>,
     "typescript": "^5.0.4"<% } %>


### PR DESCRIPTION
Resolves https://github.com/embroider-build/addon-blueprint/issues/130


Requires support for `"type": "module"` in package.json from both ember-auto-import and embroider.