### PR TITLE
Until we're on prettier v3, we can't use prettier-plugin-ember-template-tag@v1

### DIFF
--- a/files/__addonLocation__/package.json
+++ b/files/__addonLocation__/package.json
@@ -77,7 +77,7 @@
     "eslint-plugin-n": "^16.0.0",
     "eslint-plugin-prettier": "^4.0.0",
     "prettier": "^2.5.1",
-    "prettier-plugin-ember-template-tag": "^1.0.0",
+    "prettier-plugin-ember-template-tag": "^0.3.2",
     "rollup": "^3.21.8"<% if (!isExistingMonorepo) { %>,
     "rollup-plugin-copy": "^3.4.0"<% } %><% if (typescript) { %>,
     "typescript": "^5.0.4"<% } %>

--- a/files/package.json
+++ b/files/package.json
@@ -7,7 +7,7 @@
   "devDependencies": {
     "concurrently": "^8.2.0",
     "prettier": "^2.5.1",
-    "prettier-plugin-ember-template-tag": "^1.0.0"
+    "prettier-plugin-ember-template-tag": "^0.3.2"
   },
   "workspaces": [
     "<%= addonInfo.location %>",


### PR DESCRIPTION
Temporary alternative to: 
- https://github.com/embroider-build/addon-blueprint/pull/180

Still resolves: 
- https://github.com/embroider-build/addon-blueprint/issues/184



