### PR TITLE
pnpm: suggest stricter dep management

### DIFF
--- a/files/.npmrc
+++ b/files/.npmrc
@@ -1,0 +1,9 @@
+# Docs: https://pnpm.io/npmrc
+# https://github.com/emberjs/rfcs/pull/907
+
+# we don't want addons to be bad citizens of the ecosystem
+auto-install-peers=false
+
+# we want true isolation,
+# if a dependency is not declared, we want an error
+resolve-peers-from-workspace-root=false

--- a/files/__addonLocation__/.npmrc
+++ b/files/__addonLocation__/.npmrc
@@ -1,0 +1,9 @@
+# Docs: https://pnpm.io/npmrc
+# https://github.com/emberjs/rfcs/pull/907
+
+# we don't want addons to be bad citizens of the ecosystem
+auto-install-peers=false
+
+# we want true isolation,
+# if a dependency is not declared, we want an error
+resolve-peers-from-workspace-root=false

--- a/index.js
+++ b/index.js
@@ -320,7 +320,7 @@ module.exports = {
       files = files.filter((filename) => filename !== '__addonLocation__/gitignore');
       // In an existing monorepo, we typically have a single .npmrc for the whole repo.
       // We don't want to generate an .npmrc for those situations.
-      files = files.filter((filename) => filename.endsWith('.npmrc'));
+      files = files.filter((filename) => !filename.endsWith('.npmrc'));
     }
 
     return files;

--- a/index.js
+++ b/index.js
@@ -316,6 +316,9 @@ module.exports = {
       // The .gitignore is used for ignoring files that are moved to the addon from the root folder at build time
       // But this setup does not apply for an existing monorepo (all root files are ignored), so we don't need the .gitignore
       files = files.filter((filename) => filename !== '__addonLocation__/gitignore');
+      // In an existing monorepo, we typically have a single .npmrc for the whole repo.
+      // We don't want to generate an .npmrc for those situations.
+      files = files.filter((filename) => filename !== '.npmrc');
     }
 
     return files;

--- a/index.js
+++ b/index.js
@@ -318,7 +318,7 @@ module.exports = {
       files = files.filter((filename) => filename !== '__addonLocation__/gitignore');
       // In an existing monorepo, we typically have a single .npmrc for the whole repo.
       // We don't want to generate an .npmrc for those situations.
-      files = files.filter((filename) => filename !== '.npmrc');
+      files = files.filter((filename) => filename.endsWith('.npmrc'));
     }
 
     return files;

--- a/index.js
+++ b/index.js
@@ -300,6 +300,8 @@ module.exports = {
 
     if (options.addonOnly) {
       files = files.filter((filename) => filename.includes('__addonLocation__'));
+    } else {
+      files = files.filter((filename) => filename.includes('__addonLocation__/.npmrc'));
     }
 
     if (!options.typescript) {

--- a/index.js
+++ b/index.js
@@ -301,7 +301,9 @@ module.exports = {
     if (options.addonOnly) {
       files = files.filter((filename) => filename.includes('__addonLocation__'));
     } else {
-      files = files.filter((filename) => filename.includes('__addonLocation__/.npmrc'));
+      // filter out the addon-specific npmrc, as it
+      // is only applicable during --addon-only
+      files = files.filter((filename) => !filename.includes('__addonLocation__/.npmrc'));
     }
 
     if (!options.typescript) {

--- a/tests/fixtures/explicit-imports/test-app/tests/unit/import-test.ts
+++ b/tests/fixtures/explicit-imports/test-app/tests/unit/import-test.ts
@@ -5,7 +5,7 @@ import { hbs } from 'ember-cli-htmlbars';
 
 import * as myModule from 'my-addon';
 
-module('imports', function (hooks) {
+module('imports', function () {
   test('did they work', async function (assert) {
     assert.ok(myModule.MyService);
     assert.ok(myModule.JSComponent);

--- a/tests/fixtures/pnpm-addon-only/.npmrc
+++ b/tests/fixtures/pnpm-addon-only/.npmrc
@@ -1,0 +1,9 @@
+# Docs: https://pnpm.io/npmrc
+# https://github.com/emberjs/rfcs/pull/907
+
+# we don't want addons to be bad citizens of the ecosystem
+auto-install-peers=false
+
+# we want true isolation,
+# if a dependency is not declared, we want an error
+resolve-peers-from-workspace-root=false

--- a/tests/fixtures/pnpm/.npmrc
+++ b/tests/fixtures/pnpm/.npmrc
@@ -1,0 +1,9 @@
+# Docs: https://pnpm.io/npmrc
+# https://github.com/emberjs/rfcs/pull/907
+
+# we don't want addons to be bad citizens of the ecosystem
+auto-install-peers=false
+
+# we want true isolation,
+# if a dependency is not declared, we want an error
+resolve-peers-from-workspace-root=false

--- a/tests/helpers/utils.ts
+++ b/tests/helpers/utils.ts
@@ -143,15 +143,5 @@ export async function createAddon({
     preferLocal: true,
   });
 
-  // Light work-around for an upstream `@babel/core` peer issue
-  if (typeof options.cwd === 'string') {
-    await fs.writeFile(
-      fse.existsSync(path.join(options.cwd, name))
-        ? path.join(options.cwd, name, '.npmrc')
-        : path.join(options.cwd, '.npmrc'),
-      'auto-install-peers=true'
-    );
-  }
-
   return { result, name };
 }

--- a/tests/helpers/utils.ts
+++ b/tests/helpers/utils.ts
@@ -4,7 +4,6 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { execa,type Options } from 'execa';
-import fse from 'fs-extra';
 
 const DEBUG = process.env.DEBUG === 'true';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));

--- a/tests/smoke-tests/--addon-only.test.ts
+++ b/tests/smoke-tests/--addon-only.test.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import fse from 'fs-extra';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
-import { AddonHelper, dirContents } from '../helpers.js';
+import { AddonHelper, dirContents, matchesFixture } from '../helpers.js';
 
 describe('--addon-only', () => {
   let helper = new AddonHelper({ packageManager: 'pnpm', args: ['--addon-only'] });
@@ -20,6 +20,9 @@ describe('--addon-only', () => {
   it('has all the dot files', async () => {
     let contents = await dirContents(helper.projectRoot);
 
+    await matchesFixture('.npmrc', { cwd: helper.projectRoot, scenario: 'pnpm-addon-only' });
+
+    expect(contents).to.include('.npmrc');
     expect(contents).to.include('.eslintrc.cjs');
     expect(contents).to.include('.eslintignore');
     expect(contents).to.include('.prettierrc.cjs');

--- a/tests/smoke-tests/defaults.test.ts
+++ b/tests/smoke-tests/defaults.test.ts
@@ -83,6 +83,10 @@ for (let packageManager of SUPPORTED_PACKAGE_MANAGERS) {
             scenario: 'pnpm',
           });
           await matchesFixture('CONTRIBUTING.md', { cwd: helper.projectRoot, scenario: 'pnpm' });
+          await matchesFixture('.npmrc', {
+            cwd: helper.projectRoot,
+            scenario: 'pnpm',
+          });
 
           expect(testManifest.devDependencies['my-addon']).toBe('workspace:*');
 

--- a/tests/smoke-tests/within-existing-monorepo/defaults.test.ts
+++ b/tests/smoke-tests/within-existing-monorepo/defaults.test.ts
@@ -89,7 +89,7 @@ for (let packageManager of SUPPORTED_PACKAGE_MANAGERS) {
     it('ignores root files', async () => {
       expect(
         fixturify.readSync(cwd, {
-          ignore: ['my-addon', 'test-app', 'node_modules', lockFile, '.npmrc'],
+          ignore: ['my-addon', 'test-app', 'node_modules', lockFile],
         }),
         'root files have not been touched'
       ).toEqual(rootFiles);


### PR DESCRIPTION
Adds an `.npmrc` to the blueprint for both monorepo (default) and `--addon-only` outputs, which is from the pnpm RFC, 907. 

