### PR TITLE
fix: glint addon docs link for template registry

### DIFF
--- a/files/__addonLocation__/src/template-registry.ts
+++ b/files/__addonLocation__/src/template-registry.ts
@@ -1,6 +1,6 @@
 // Easily allow apps, which are not yet using strict mode templates, to consume your Glint types, by importing this file.
 // Add all your components, helpers and modifiers to the template registry here, so apps don't have to do this.
-// See https://typed-ember.gitbook.io/glint/using-glint/ember/authoring-addons
+// See https://typed-ember.gitbook.io/glint/environments/ember/authoring-addons
 
 // import type MyComponent from './components/my-component';
 

--- a/tests/fixtures/explicit-imports/my-addon/src/template-registry.ts
+++ b/tests/fixtures/explicit-imports/my-addon/src/template-registry.ts
@@ -4,7 +4,7 @@ import { default as Nested } from './components/nested/index.js';
 
 // Easily allow apps, which are not yet using strict mode templates, to consume your Glint types, by importing this file.
 // Add all your components, helpers and modifiers to the template registry here, so apps don't have to do this.
-// See https://typed-ember.gitbook.io/glint/using-glint/ember/authoring-addons
+// See https://typed-ember.gitbook.io/glint/environments/ember/authoring-addons
 
 // import type MyComponent from './components/my-component';
 


### PR DESCRIPTION
The current link results in a 404.