### PR TITLE
Update config templates to properly handle .gts files

### DIFF
--- a/files/__addonLocation__/.eslintrc.cjs
+++ b/files/__addonLocation__/.eslintrc.cjs
@@ -23,7 +23,7 @@ module.exports = {
   overrides: [
 <% if (typescript) { %>    // ts files
     {
-      files: ['**/*.ts'],
+      files: ['**/*.ts', '**/*.gts'],
       extends: [
         'plugin:@typescript-eslint/eslint-recommended',
         'plugin:@typescript-eslint/recommended',

--- a/files/__addonLocation__/babel.config.json
+++ b/files/__addonLocation__/babel.config.json
@@ -1,5 +1,5 @@
 {
-<% if (typescript) { %>  "presets": [["@babel/preset-typescript"]],
+<% if (typescript) { %>  "presets": [["@babel/preset-typescript", { "allExtensions": true, "onlyRemoveTypeImports": true }]],
 <% } %>  "plugins": [
     "@embroider/addon-dev/template-colocation-plugin",
     "@babel/plugin-transform-class-static-block",

--- a/tests/fixtures/default/my-addon/src/components/template-import.gjs
+++ b/tests/fixtures/default/my-addon/src/components/template-import.gjs
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import TemplateOnly from './template-only';
 import { on } from '@ember/modifier';
 
-export default class CoLocated extends Component {
+export default class TemplateImport extends Component {
   <template>
     Hello from a GJS file but also <TemplateOnly />
 

--- a/tests/fixtures/typescript/my-addon/src/components/another-gts.gts
+++ b/tests/fixtures/typescript/my-addon/src/components/another-gts.gts
@@ -1,0 +1,14 @@
+import Component from '@glimmer/component';
+
+interface Signature {
+  Element: HTMLDivElement;
+}
+
+export default class AnotherGts extends Component<Signature> {
+  greeting = "Hello";
+  <template>
+    <div ...attributes>
+      {{this.greeting}} from another GTS file!
+    </div>
+  </template>
+}

--- a/tests/fixtures/typescript/my-addon/src/components/template-import.gts
+++ b/tests/fixtures/typescript/my-addon/src/components/template-import.gts
@@ -1,0 +1,28 @@
+import Component from '@glimmer/component';
+import TemplateOnly from './template-only';
+import AnotherGts from './another-gts.gts'; // N.B. relative imports inside a v2 addon should have explicit file extensions (this is consistent with how node treats ES modules)
+import { on } from '@ember/modifier';
+import { action } from '@ember/object';
+import { fn } from '@ember/helper';
+
+interface Signature {
+  Element: HTMLDivElement;
+  Args: {
+    saying?: string;
+  };
+}
+
+export default class TemplateImport extends Component<Signature> {
+  <template>
+    <div ...attributes>
+      Hello from a GTS file but also <TemplateOnly /> and <AnotherGts />
+
+      <button {{on "click" (fn this.saySomething @saying)}}></button>
+    </div>
+  </template>
+
+  @action
+  saySomething(sayWhat: string | undefined) {
+    console.log(sayWhat || "something");
+  }
+}

--- a/tests/fixtures/typescript/test-app/tests/rendering/template-import-test.ts
+++ b/tests/fixtures/typescript/test-app/tests/rendering/template-import-test.ts
@@ -7,8 +7,8 @@ module('Rendering | template-import', function(hooks) {
   setupRenderingTest(hooks);
 
   test('it renders', async function(assert) {
-    await render(hbs`<TemplateImport />`);
+    await render(hbs`<TemplateImport @saying="what" />`);
 
-    assert.dom().hasText('Hello from a GJS file but also Hello from a template-only component');
+    assert.dom().hasText('Hello from a GTS file but also Hello from a template-only component and Hello from another GTS file!');
   })
 });

--- a/tests/smoke-tests/--typescript.test.ts
+++ b/tests/smoke-tests/--typescript.test.ts
@@ -97,8 +97,8 @@ for (let packageManager of SUPPORTED_PACKAGE_MANAGERS) {
       let testResult = await helper.run('test');
 
       expect(testResult.exitCode).toEqual(0);
-      expect(testResult.stdout).to.include('# tests 4');
-      expect(testResult.stdout).to.include('# pass  4');
+      expect(testResult.stdout).to.include('# tests 5');
+      expect(testResult.stdout).to.include('# pass  5');
       expect(testResult.stdout).to.include('# fail  0');
     });
   });


### PR DESCRIPTION
This is an attempt to illustrate a problem I had doing a v1 -> v2 addon migration for an addon that includes .gts components.

The new test fails with the following output:

```
prepare: > concurrently 'npm:build:*'
.. prepare: [js] > my-addon@0.0.0 build:js
.. prepare: [js] > rollup --config
.. prepare: [js] 
.. prepare: [js]  → dist...
.. prepare: [js] [!] (plugin babel) SyntaxError: /private/var/folders/lf/n0vr44g54f70hr2sh9w5hmq00000gn/T/v2-addon-blueprint--52OYD5/my-addon/my-addon/src/components/template-import.gts: Unexpected reserved word 'interface'. (7:0)
.. prepare: [js] 
.. prepare: [js]    5 | import { action } from '@ember/object';
.. prepare: [js]    6 | import { fn } from '@ember/helper';
.. prepare: [js] >  7 | interface Signature {
.. prepare: [js]      | ^
.. prepare: [js]    8 |     Element: HTMLDivElement;
.. prepare: [js]    9 |     Args: {
.. prepare: [js]   10 |         saying?: string;
.. prepare: [js] src/components/template-import.gts (7:0)
.. prepare: [js]     at instantiate (/private/var/folders/lf/n0vr44g54f70hr2sh9w5hmq00000gn/T/v2-addon-blueprint--52OYD5/my-addon/node_modules/.pnpm/@babel+parser@7.22.13/node_modules/@babel/parser/src/parse-error/credentials.ts:62:21)
.. prepare: [js]     at toParseError (/private/var/folders/lf/n0vr44g54f70hr2sh9w5hmq00000gn/T/v2-addon-blueprint--52OYD5/my-addon/node_modules/.pnpm/@babel+parser@7.22.13/node_modules/@babel/parser/src/parse-error.ts:60:12)
.. prepare: [js]     at Parser.raise (/private/var/folders/lf/n0vr44g54f70hr2sh9w5hmq00000gn/T/v2-addon-blueprint--52OYD5/my-addon/node_modules/.pnpm/@babel+parser@7.22.13/node_modules/@babel/parser/src/tokenizer/index.ts:1487:19)
.. prepare: [js]     at Parser.checkReservedWord (/private/var/folders/lf/n0vr44g54f70hr2sh9w5hmq00000gn/T/v2-addon-blueprint--52OYD5/my-addon/node_modules/.pnpm/@babel+parser@7.22.13/node_modules/@babel/parser/src/parser/expression.ts:2808:12)
.. prepare: [js]     at Parser.parseIdentifierName (/private/var/folders/lf/n0vr44g54f70hr2sh9w5hmq00000gn/T/v2-addon-blueprint--52OYD5/my-addon/node_modules/.pnpm/@babel+parser@7.22.13/node_modules/@babel/parser/src/parser/expression.ts:2769:12)
.. prepare: [js]     at Parser.parseIdentifier (/private/var/folders/lf/n0vr44g54f70hr2sh9w5hmq00000gn/T/v2-addon-blueprint--52OYD5/my-addon/node_modules/.pnpm/@babel+parser@7.22.13/node_modules/@babel/parser/src/parser/expression.ts:2734:23)
.. prepare: [js]     at Parser.parseExprAtom (/private/var/folders/lf/n0vr44g54f70hr2sh9w5hmq00000gn/T/v2-addon-blueprint--52OYD5/my-addon/node_modules/.pnpm/@babel+parser@7.22.13/node_modules/@babel/parser/src/parser/expression.ts:1296:27)
.. prepare: [js]     at Parser.parseExprSubscripts (/private/var/folders/lf/n0vr44g54f70hr2sh9w5hmq00000gn/T/v2-addon-blueprint--52OYD5/my-addon/node_modules/.pnpm/@babel+parser@7.22.13/node_modules/@babel/parser/src/parser/expression.ts:710:23)
.. prepare: [js]     at Parser.parseUpdate (/private/var/folders/lf/n0vr44g54f70hr2sh9w5hmq00000gn/T/v2-addon-blueprint--52OYD5/my-addon/node_modules/.pnpm/@babel+parser@7.22.13/node_modules/@babel/parser/src/parser/expression.ts:687:21)
.. prepare: [js]     at Parser.parseMaybeUnary (/private/var/folders/lf/n0vr44g54f70hr2sh9w5hmq00000gn/T/v2-addon-blueprint--52OYD5/my-addon/node_modules/.pnpm/@babel+parser@7.22.13/node_modules/@babel/parser/src/parser/expression.ts:649:23)
.. prepare: [js] 
.. prepare: [js] npm run build:js exited with code 1
```