### PR TITLE
Remove `ember-disable-prototype-extensions` from test app

### DIFF
--- a/additional-test-app-package.json
+++ b/additional-test-app-package.json
@@ -1,7 +1,6 @@
 {
   "devDependencies": {
     "@embroider/test-setup": "^3.0.1",
-    "ember-disable-prototype-extensions": "^1.1.3",
     "ember-try": "^3.0.0",
     "ember-source-channel-url": "^3.0.0"
   }


### PR DESCRIPTION
Since Ember CLI v4.9, apps are generated with `EXTEND_PROTOTYPES: false` by default.
Though, I would understand if this PR is a bit too soon.