### PR TITLE
Use correct extension for Prettier config file in ESLint config

### DIFF
--- a/files/__addonLocation__/.eslintrc.cjs
+++ b/files/__addonLocation__/.eslintrc.cjs
@@ -36,7 +36,7 @@ module.exports = {
     {
       files: [
         './.eslintrc.cjs',
-        './.prettierrc.js',
+        './.prettierrc.cjs',
         './.template-lintrc.cjs',
         './addon-main.cjs',
       ],


### PR DESCRIPTION
Because => https://github.com/embroider-build/addon-blueprint/blob/main/files/__addonLocation__/.prettierrc.cjs