### PR TITLE
Upgrade @typescript-eslint dependencies

### DIFF
--- a/files/__addonLocation__/package.json
+++ b/files/__addonLocation__/package.json
@@ -65,8 +65,8 @@
     "@types/ember__error": "^4.0.3",
     "@types/ember__component": "^4.0.14",
     "@types/ember__routing": "^4.0.13",
-    "@typescript-eslint/eslint-plugin": "^5.30.5",
-    "@typescript-eslint/parser": "^5.30.5",<% } %>
+    "@typescript-eslint/eslint-plugin": "^6.7.2",
+    "@typescript-eslint/parser": "^6.7.2",<% } %>
     "@rollup/plugin-babel": "^6.0.3",
     "babel-plugin-ember-template-compilation": "^2.2.0",
     "concurrently": "^8.0.1",


### PR DESCRIPTION
`@typescript-eslint@<5` is not compatible with TS v5