### PR TITLE
Better defaults for publicEntrypoints and appReexports

### DIFF
--- a/files/__addonLocation__/rollup.config.mjs
+++ b/files/__addonLocation__/rollup.config.mjs
@@ -15,12 +15,22 @@ export default {
   plugins: [
     // These are the modules that users should be able to import from your
     // addon. Anything not listed here may get optimized away.
-    addon.publicEntrypoints(['components/**/*.js', 'index.js'<% if (typescript) {%>, 'template-registry.js'<% } %>]),
+    // By default all your JavaScript modules (**/*.js) will be importable.
+    // But you are encouraged to tweak this to only cover the modules that make
+    // up your addon's public API. Also make sure your package.json#exports
+    // is aligned to the config here.
+    // See https://github.com/embroider-build/embroider/blob/main/docs/v2-faq.md#how-can-i-define-the-public-exports-of-my-addon
+    addon.publicEntrypoints(['**/*.js', 'index.js'<% if (typescript) {%>, 'template-registry.js'<% } %>]),
 
     // These are the modules that should get reexported into the traditional
     // "app" tree. Things in here should also be in publicEntrypoints above, but
     // not everything in publicEntrypoints necessarily needs to go here.
-    addon.appReexports(['components/**/*.js']),
+    addon.appReexports([
+      'components/**/*.js',
+      'helpers/**/*.js',
+      'modifiers/**/*.js',
+      'services/**/*.js',
+    ]),
 
     // Follow the V2 Addon rules about dependencies. Your code can import from
     // `dependencies` and `peerDependencies` as well as standard Ember-provided

--- a/tests/rollup-build-tests/explicit-imports.test.ts
+++ b/tests/rollup-build-tests/explicit-imports.test.ts
@@ -48,8 +48,8 @@ describe(`rollup-build | explicit-imports`, () => {
         expect(files).to.include(
           file,
           `expected ${file} to be included in the expected list of files: ${expected.join(
-            ' '
-          )}, however, only ${files.join(', ')} were found.`
+            ' ',
+          )}, however, only ${files.join(', ')} were found.`,
         );
       }
     }
@@ -57,6 +57,7 @@ describe(`rollup-build | explicit-imports`, () => {
     hasEachOf(await dirContents(distDir), [
       '_app_',
       'components',
+      'services',
       'index.js',
       'index.js.map',
       'template-registry.js',
@@ -72,10 +73,10 @@ describe(`rollup-build | explicit-imports`, () => {
       'template-registry.d.ts.map',
     ]);
 
-    expect(await dirContents(path.join(distDir, 'services'))).to.deep.equal(
-      [],
-      'my-service.js is not in the app-re-exports'
-    );
+    expect(await dirContents(path.join(distDir, 'services'))).to.deep.equal([
+      'my-service.js',
+      'my-service.js.map',
+    ]);
     expect(await dirContents(path.join(declarationsDir, 'services'))).to.deep.equal([
       'my-service.d.ts',
       'my-service.d.ts.map',


### PR DESCRIPTION
As [discussed in last week's team meeting](https://github.com/emberjs/core-notes/blob/master/st-embroider/2023/2023-09-19.md#discuss-better-defaults-for-publicentrypoints-and-appreexports-simonihmig). Fixes #193. 