### PR TITLE
Add a service usage to the TS tests to help guide our babel config for TS.

### DIFF
--- a/files/__addonLocation__/babel.config.json
+++ b/files/__addonLocation__/babel.config.json
@@ -1,8 +1,7 @@
 {
-<% if (typescript) { %>  "presets": [["@babel/preset-typescript", { "allExtensions": true, "onlyRemoveTypeImports": true, "allowDeclareFields": true }]],
-<% } %>
   "plugins": [
-    "@embroider/addon-dev/template-colocation-plugin",
+<% if (typescript) { %>  ["@babel/plugin-transform-typescript", { "allExtensions": true, "onlyRemoveTypeImports": true, "allowDeclareFields": true }],
+<% } %>    "@embroider/addon-dev/template-colocation-plugin",
     "@babel/plugin-transform-class-static-block",
     ["babel-plugin-ember-template-compilation", {
       "targetFormat": "hbs",

--- a/files/__addonLocation__/babel.config.json
+++ b/files/__addonLocation__/babel.config.json
@@ -1,6 +1,7 @@
 {
-<% if (typescript) { %>  "presets": [["@babel/preset-typescript", { "allExtensions": true, "onlyRemoveTypeImports": true }]],
-<% } %>  "plugins": [
+<% if (typescript) { %>  "presets": [["@babel/preset-typescript", { "allExtensions": true, "onlyRemoveTypeImports": true, "allowDeclareFields": true }]],
+<% } %>
+  "plugins": [
     "@embroider/addon-dev/template-colocation-plugin",
     "@babel/plugin-transform-class-static-block",
     ["babel-plugin-ember-template-compilation", {

--- a/files/__addonLocation__/package.json
+++ b/files/__addonLocation__/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.17.0",
-    <% if (typescript) { %>"@babel/preset-typescript": "^7.18.6"<% } else { %>"@babel/eslint-parser": "^7.19.1"<% } %>,
+    <% if (typescript) { %>"@babel/plugin-transform-typescript": "^7.22.15"<% } else { %>"@babel/eslint-parser": "^7.19.1"<% } %>,
     "@babel/plugin-proposal-class-properties": "^7.16.7",
     "@babel/plugin-proposal-decorators": "^7.20.13",
     "@babel/plugin-transform-class-static-block": "^7.20.0",

--- a/tests/fixtures/typescript/my-addon/src/components/co-located-ts.ts
+++ b/tests/fixtures/typescript/my-addon/src/components/co-located-ts.ts
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { service } from '@ember/service';
-import Example from '../services/example';
+import type Example from '../services/example.ts';
 
 export default class CoLocatedTs extends Component {
   @service declare example: Example;

--- a/tests/fixtures/typescript/my-addon/src/components/co-located-ts.ts
+++ b/tests/fixtures/typescript/my-addon/src/components/co-located-ts.ts
@@ -1,5 +1,9 @@
 import Component from '@glimmer/component';
+import { service } from '@ember/service';
+import Example from '../services/example';
 
 export default class CoLocatedTs extends Component {
+  @service declare example: Example;
+
   whereAmI = 'from a co-located TS component';
 }

--- a/tests/fixtures/typescript/my-addon/src/services/example.ts
+++ b/tests/fixtures/typescript/my-addon/src/services/example.ts
@@ -1,0 +1,5 @@
+import Service from '@ember/service';
+
+export default class Example extends Service {
+  foo = 'hello from service';
+}

--- a/tests/smoke-tests/--typescript.test.ts
+++ b/tests/smoke-tests/--typescript.test.ts
@@ -49,7 +49,7 @@ for (let packageManager of SUPPORTED_PACKAGE_MANAGERS) {
 
     it('build and test', async () => {
       // Copy over fixtures
-      await helper.fixtures.use('./my-addon/src/components');
+      await helper.fixtures.use('./my-addon/src');
       await helper.fixtures.use('./test-app/tests');
       // Sync fixture with project's lint / formatting configuration
       // (controlled by ember-cli)
@@ -82,6 +82,7 @@ for (let packageManager of SUPPORTED_PACKAGE_MANAGERS) {
         'components',
         'index.js',
         'index.js.map',
+        'services',
         'template-registry.js',
         'template-registry.js.map',
       ]);
@@ -102,6 +103,7 @@ for (let packageManager of SUPPORTED_PACKAGE_MANAGERS) {
         'components',
         'index.d.ts',
         'index.d.ts.map',
+        'services',
         'template-registry.d.ts',
         'template-registry.d.ts.map',
       ]);


### PR DESCRIPTION
Previously, 
```ts
class Demo {
  @service declare foo: Foo;
}
```
would error about not having `allowDeclareFields` enabled.

However, the preset, while documenting this feature, does not enable it.
So, we're left with removing the preset entirely and configuring the TS transform plugin directly.