### PR TITLE
Update tsconfig to have verbatimModuleSyntax and document reasoning for the tsconfig options

### DIFF
--- a/files/__addonLocation__/tsconfig.json
+++ b/files/__addonLocation__/tsconfig.json
@@ -9,7 +9,18 @@
   },
   "compilerOptions": {
     "allowJs": true,
-    "allowImportingTsExtensions": true,
-    "declarationDir": "declarations"
+    "declarationDir": "declarations",
+
+    /**
+      We don't want to include types dependencies in our compiled output, so tell TypeScript
+      to enforce using `import type` instead of `import` for Types.
+     */
+    "verbatimModuleSyntax": true,
+
+    /**
+      We want our tooling to know how to resolve our custom files so the appropriate plugins
+      can do the proper transformations on those files.
+    */
+    "allowImportingTsExtensions": true
   }
 }


### PR DESCRIPTION
Resolves #207. 

Don't need a lint when we ts can tell us what's wrong.
(or rather, this is the lint, or part of the lint -- we could want to enforce more control over this)