### PR TITLE
fix: configure glint for ember-template-imports

### DIFF
--- a/files/__addonLocation__/unpublished-development-types/index.d.ts
+++ b/files/__addonLocation__/unpublished-development-types/index.d.ts
@@ -2,6 +2,7 @@
 // These will *not* be published as part of your addon, so be careful that your published code does not rely on them!
 
 import '@glint/environment-ember-loose';
+import '@glint/environment-ember-template-imports';
 
 declare module '@glint/environment-ember-loose/registry' {
   // Remove this once entries have been added! 👇


### PR DESCRIPTION
Currently we already add `"ember-template-imports"` to `glint.environment` in `tsconfig.json`. 

I believe we should also add this import in order to configure Glint completely for ember-template-imports?