### PR TITLE
Use --skip-cleanup for ember-try for faster-exiting try-scenarios

### DIFF
--- a/files/.github/workflows/ci.yml
+++ b/files/.github/workflows/ci.yml
@@ -70,5 +70,5 @@ jobs:
       - name: Install Dependencies
         run: <%= yarn ? 'yarn install --frozen-lockfile' : 'npm ci' %><%}%>
       - name: Run Tests
-        run: ./node_modules/.bin/ember try:one ${{ matrix.try-scenario }}
+        run: ./node_modules/.bin/ember try:one ${{ matrix.try-scenario }} --skip-cleanup
         working-directory: <%= testAppInfo.location %>

--- a/tests/fixtures/default/.github/workflows/ci.yml
+++ b/tests/fixtures/default/.github/workflows/ci.yml
@@ -70,5 +70,5 @@ jobs:
       - name: Install Dependencies
         run: npm ci
       - name: Run Tests
-        run: ./node_modules/.bin/ember try:one ${{ matrix.try-scenario }}
+        run: ./node_modules/.bin/ember try:one ${{ matrix.try-scenario }} --skip-cleanup
         working-directory: test-app

--- a/tests/fixtures/pnpm/.github/workflows/ci.yml
+++ b/tests/fixtures/pnpm/.github/workflows/ci.yml
@@ -61,5 +61,5 @@ jobs:
         with:
           node-version: 16
       - name: Run Tests
-        run: ./node_modules/.bin/ember try:one ${{ matrix.try-scenario }}
+        run: ./node_modules/.bin/ember try:one ${{ matrix.try-scenario }} --skip-cleanup
         working-directory: test-app

--- a/tests/fixtures/yarn/.github/workflows/ci.yml
+++ b/tests/fixtures/yarn/.github/workflows/ci.yml
@@ -70,5 +70,5 @@ jobs:
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
       - name: Run Tests
-        run: ./node_modules/.bin/ember try:one ${{ matrix.try-scenario }}
+        run: ./node_modules/.bin/ember try:one ${{ matrix.try-scenario }} --skip-cleanup
         working-directory: test-app


### PR DESCRIPTION
Speed up ci. We don't need to clean.