### PR TITLE
Support index-modules in exports

### DIFF
--- a/files/__addonLocation__/package.json
+++ b/files/__addonLocation__/package.json
@@ -102,8 +102,8 @@
       "default": "./dist/index.js"
     },
     "./*": {
-      "types": "./declarations/*.d.ts",
-      "default": "./dist/*.js"
+      "types": ["./declarations/*.d.ts", "./declarations/*/index.d.ts"],
+      "default": ["./dist/*.js", "./dist/*/index.js"]
     },<% } else { %>
     ".": "./dist/index.js",
     "./*": "./dist/*.js",<% } %>
@@ -112,7 +112,8 @@
   "typesVersions": {
     "*": {
       "*": [
-        "declarations/*"
+        "declarations/*",
+        "declarations/*/index"
       ]
     }
   }<% } %>


### PR DESCRIPTION
This is not _necessarily_ something I expect to get merged immediately, more so to start a conversation...

The problem this is addressing is that index-files, which are supported in v1 addons and the default node module resolution, are not working ootb in v2 addons, due to our explicit `exports` mapping. Say you put a `foo/index.js` module into `/src`, then currently the only way to import that is by `import foo from 'addon/foo/index'`, which I think is pretty much unexpected. 

This is especially annoying when migrating from v1 addons. For example a common suggestion would be to move your addon's `addon-test-support` to `src/test-support`. But again that does not allow you to import from `addon/test-support` as expected, so makes this a breaking change.

Ideally I think, we would allow alternatives, so that `import foo from 'addon/foo'` can be satisfied _either_ by `src/foo.js` or `src/foo/index.js`.

And actually this seems to be possible, with the changes in this PR. Both webpack ([docs](https://webpack.js.org/guides/package-exports/#alternatives))and TypeScript seem to support an array of alternative modules in `exports`. And TypeScript has supported that for long in `typesVersions`, which is also what the [v1 blueprint does](https://github.com/ember-cli/ember-cli/blob/master/blueprints/addon/index.js#L101-L107)!

The only problem: vite supports array-based alternatives, but does no file-check, just takes whatever matches first AFAIU, see https://github.com/vitejs/vite/issues/4439#issuecomment-1465224035. Which is not what we need to support this use case.

The alternative to this "just works" approach would be to force users to explicitly define the `exports` mapping. But this also does not seem good, because
* not too many folks really know about `exports` and how they work I think. And if resolving an index-module does not work, you won't get a really helpful error message like saying "tweak your exports".
* you might ship breaking changes accidentally
* if you have many nested files using index files, it become very tedious to explicitly map them, as AFAIK you cannot do that with any globs, so you would have an explicit entry per index-file. Which also can get easily out of sync.

Thoughts?