### PR TITLE
Add missing files to --addon-only output

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,6 +31,15 @@ async function createTmp() {
 
 const filesToCopyFromRootToAddonDuringBuild = ['README.md', 'LICENSE.md'];
 const filesToCopyFromRootToAddonInExistingMonorepo = ['README.md', 'CONTRIBUTING.md'];
+const filesToCopyFromRootToAddonInAddonOnlyMode = [
+  'config/ember-cli-update.json',
+  '.editorconfig',
+  '.prettierignore',
+  '.prettierrc.cjs',
+  'CONTRIBUTING.md',
+  'LICENSE.md',
+  'README.md',
+];
 
 module.exports = {
   description,
@@ -300,7 +309,7 @@ module.exports = {
     let files = this._super.files.apply(this, arguments);
 
     if (options.addonOnly) {
-      files = files.filter((filename) => filename.includes('__addonLocation__'));
+      files = files.filter((filename) => filename.includes('__addonLocation__') || filesToCopyFromRootToAddonInAddonOnlyMode.includes(filename));
     } else {
       // filter out the addon-specific npmrc, as it
       // is only applicable during --addon-only

--- a/tests/smoke-tests/--addon-only.test.ts
+++ b/tests/smoke-tests/--addon-only.test.ts
@@ -17,18 +17,34 @@ describe('--addon-only', () => {
     await helper.clean();
   });
 
-  it('has all the dot files', async () => {
-    let contents = await dirContents(helper.projectRoot);
+  it('has all the files', async () => {
+    let rootContents = await dirContents(helper.projectRoot);
 
     await matchesFixture('.npmrc', { cwd: helper.projectRoot, scenario: 'pnpm-addon-only' });
 
-    expect(contents).to.include('.npmrc');
-    expect(contents).to.include('.eslintrc.cjs');
-    expect(contents).to.include('.eslintignore');
-    expect(contents).to.include('.prettierrc.cjs');
-    expect(contents).to.include('.prettierignore');
-    expect(contents).to.include('.template-lintrc.cjs');
-    expect(contents).to.include('.gitignore');
+    expect(rootContents).to.include('.editorconfig');
+    expect(rootContents).to.include('.eslintignore');
+    expect(rootContents).to.include('.eslintrc.cjs');
+    expect(rootContents).to.include('.gitignore'); 
+    expect(rootContents).to.include('.npmrc');
+    expect(rootContents).to.include('.prettierignore');
+    expect(rootContents).to.include('.prettierrc.cjs');
+    expect(rootContents).to.include('.template-lintrc.cjs');
+    expect(rootContents).to.include('CONTRIBUTING.md');
+    expect(rootContents).to.include('LICENSE.md');
+    expect(rootContents).to.include('README.md');
+    expect(rootContents).to.include('addon-main.cjs');
+    expect(rootContents).to.include('babel.config.json');
+    expect(rootContents).to.include('package.json');
+    expect(rootContents).to.include('rollup.config.mjs');
+
+    let configContents = await dirContents(path.join(helper.projectRoot, 'config'));
+    
+    expect(configContents).to.include('ember-cli-update.json');
+
+    let srcContents = await dirContents(path.join(helper.projectRoot, 'src'));
+    
+    expect(srcContents).to.include('index.js');
   });
 
   it('is not a monorepo', async () => {


### PR DESCRIPTION
![image](https://github.com/embroider-build/addon-blueprint/assets/200884/163a7c7a-4033-4d88-9ca0-aa6b84e127b2)
