### PR TITLE
Readme: minor formatting fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ ember addon my-addon -b @embroider/addon-blueprint --test-app-name=test-app-for-
 
 By default, `test-app` will be used.
 
-### `--addon-only`
+#### `--addon-only`
 
 Will only create the addon, similar to the v1 addon behavior of `ember addon my-addon`.
 This is useful for incremental migrations of v1 addons to v2 addons where the process from the


### PR DESCRIPTION
One of the headings was larger than its siblings.

* [Rendered before](https://github.com/embroider-build/addon-blueprint/blob/main/README.md#--addon-only)
* [Rendered after](https://github.com/embroider-build/addon-blueprint/blob/8ab7c0f282d2bb04c6d7c7de1de23a043444d616/README.md#--addon-only)