### PR TITLE
Specify rootDir so that declarations can always be emitted with the correct paths.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,8 @@ jobs:
 
           # build-only tests for testing if the rollup config works at all
           - rollup-build
+          - declarations-configuration
+
     steps:
       - uses: actions/checkout@v3
       - uses: wyvox/action-setup-pnpm@v2

--- a/files/__addonLocation__/tsconfig.json
+++ b/files/__addonLocation__/tsconfig.json
@@ -12,6 +12,17 @@
     "declarationDir": "declarations",
 
     /**
+      https://www.typescriptlang.org/tsconfig#rootDir
+      "Default: The longest common path of all non-declaration input files."
+      Because we want our declarations' structure to match our rollup output,
+      we need this "rootDir" to match the "srcDir" in the rollup.config.mjs.
+      
+      This way, we can have simpler `package.json#exports` that matches 
+      imports to files on disk
+    */
+    "rootDir": "./src",
+
+    /**
       We don't want to include types dependencies in our compiled output, so tell TypeScript
       to enforce using `import type` instead of `import` for Types.
      */

--- a/files/__addonLocation__/tsconfig.json
+++ b/files/__addonLocation__/tsconfig.json
@@ -14,21 +14,26 @@
     /**
       https://www.typescriptlang.org/tsconfig#rootDir
       "Default: The longest common path of all non-declaration input files."
+
       Because we want our declarations' structure to match our rollup output,
       we need this "rootDir" to match the "srcDir" in the rollup.config.mjs.
-      
-      This way, we can have simpler `package.json#exports` that matches 
+
+      This way, we can have simpler `package.json#exports` that matches
       imports to files on disk
     */
     "rootDir": "./src",
 
     /**
+      https://www.typescriptlang.org/tsconfig#verbatimModuleSyntax
+
       We don't want to include types dependencies in our compiled output, so tell TypeScript
       to enforce using `import type` instead of `import` for Types.
      */
     "verbatimModuleSyntax": true,
 
     /**
+      https://www.typescriptlang.org/tsconfig#allowImportingTsExtensions
+
       We want our tooling to know how to resolve our custom files so the appropriate plugins
       can do the proper transformations on those files.
     */

--- a/tests/rollup-build-tests/declarations.test.ts
+++ b/tests/rollup-build-tests/declarations.test.ts
@@ -1,0 +1,51 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+import fse from 'fs-extra';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { AddonHelper, dirContents } from '../helpers.js';
+
+/**
+ * These tests are to ensure that for typescript, we've configured the tsconfig.json correctly
+ */
+describe(`declarations-configuration`, () => {
+  let declarationsDir = '';
+  let helper = new AddonHelper({
+    packageManager: 'pnpm',
+    args: ['--typescript'],
+    scenario: 'explicit-imports',
+  });
+
+  beforeAll(async () => {
+    await helper.setup();
+    await helper.installDeps();
+
+    declarationsDir = path.join(helper.addonFolder, 'declarations');
+  });
+
+  afterAll(async () => {
+    await helper.clean();
+  });
+
+  describe('rootDir', () => {
+    it('there are no top-level files, only nested in folders', async () => {
+      await fse.rm(path.join(helper.addonFolder, 'src'), { recursive: true });
+      await fse.mkdirp(path.join(helper.addonFolder, 'src/components'));
+      await fs.writeFile(path.join(helper.addonFolder, 'src/components/example.ts'), '/* empty file */');
+
+      let buildResult = await helper.build();
+
+      expect(buildResult.exitCode).toEqual(0);
+
+      expect(await dirContents(declarationsDir)).to.deep.equal([
+        'components',
+      ]);
+
+      expect(await dirContents(path.join(declarationsDir, 'components'))).to.deep.equal([
+        'example.d.ts',
+        'example.d.ts.map'
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
Resolves: https://github.com/typed-ember/glint/issues/658