### PR TITLE
Output each tagged version to a repo for easier comparisons / reproductions

### DIFF
--- a/.github/workflows/sync-output-repo.yml
+++ b/.github/workflows/sync-output-repo.yml
@@ -1,0 +1,90 @@
+# This Workflow requires a GITHUB_AUTH token that can push to the editor output repos
+# - https://github.com/embroider-build/v2-addon-output
+#
+# NOTE:
+#   ember-addon-output and ember-new-output have tags for each release, as well as branches
+#   for each lts, master (beta), and stable (release)
+#
+#   editor-output has a branch per-editor / scenario.
+#   so branches form the pattern ${service}-{addon|app}-output{-typescript ?}
+name: Sync Output Repo
+
+on:
+  # Manual run
+  workflow_dispatch:
+    inputs:
+      version:
+        required: true
+        type: string
+        description: 'Specify the released version of @embroider/addon-blueprint to use to generate / update the output repos. Should be full semver version, and without a leading "v"'
+  push:
+    tags:
+      - 'v*'
+
+# https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
+# https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
+#
+#  GITHUB_REF      - github.ref      - refs/tags/<tag-name>
+#  GITHUB_REF_NAME - github.ref_name - <tag-name>
+#  GITHUB_REF_TYPE - github.ref_type - branch or tag
+
+env:
+  GIT_NAME: 'github-actions[bot]'
+  GIT_EMAIL: 'github-actions+bot@users.noreply.github.com'
+
+jobs:
+  verify-inputs:
+    name: "Verify Inputs"
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.determine.outputs.version }}
+      tag: ${{ steps.determine.outputs.tag }}
+
+    steps:
+      - id: determine
+        run: |
+          if [[ "${{ github.event.inputs.version }}" != "" ]]; then
+            TAG="v${{ github.event.inputs.version }}"
+            VERSION="${{ github.event.inputs.version }}"
+          elif [[ "${{ github.ref_name }}" != "" ]]; then
+            TAG="${{github.ref_name}}"
+            _version="${{github.ref_name}}"
+            VERSION="${_version/v/''}"
+          else
+            echo "Could not determine tag / version"
+            echo ""
+            echo "github.ref_name = ${{ github.ref_name }}"
+            echo "event.inputs.version = ${{ github.event.inputs.version }}"
+            exit 1;
+          fi
+
+          if [[ "$VERSION" == v* ]]; then
+            echo "version, $VERSION, may not start with a 'v' character"
+            exit 1;
+          fi
+
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+
+  push-output:
+    name: "Push to output repo (${{ matrix.variant }})"
+    runs-on: ubuntu-latest
+    needs: [verify-inputs]
+    strategy:
+      fail-fast: false
+      matrix:
+        variant: ["javascript", "typescript"]
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: wyvox/action-setup-pnpm@v3
+      - name: "Configure Git"
+        run: |
+          git config --global user.name "${{ env.GIT_NAME }}"
+          git config --global user.email "${{ env.GIT_EMAIL }}"
+      - name: Publish ${{ matrix.variant }} branches
+        run: node ./dev/update-output-repo.mjs ${{ needs.verify-inputs.outputs.version }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+          VARIANT: ${{ matrix.variant }}

--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,3 @@
 /.eslintrc.cjs
 /.prettierrc.cjs
+/dev/


### PR DESCRIPTION
Repo that will be pushed to: https://github.com/embroider-build/v2-addon-output

Inspired by ember-cli's output repo automation.