### PR TITLE
Update generated ci.yml

### DIFF
--- a/tests/fixtures/pnpm/.github/workflows/ci.yml
+++ b/tests/fixtures/pnpm/.github/workflows/ci.yml
@@ -12,36 +12,59 @@ concurrency:
    cancel-in-progress: true
 
 jobs:
+  # Fills the dep cache so parallel jobs can start faster
+  # also, if we have a lockfile issue, it's not worth trying the rust of the CI Jobs
+  setup:
+    name: "Setup"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: wyvox/action-setup-pnpm@v3
+        with:
+          node-version: 20
+
   test:
     name: "Tests"
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: wyvox/action-setup-pnpm@v3
         with:
-          node-version: 16
-      - name: Lint
-        run: pnpm lint
+          node-version: 20
       - name: Run Tests
         run: pnpm test
+
+  lint:
+    name: "Lint"
+    runs-on: ubuntu-latest
+    needs: [setup]
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: wyvox/action-setup-pnpm@v3
+        with:
+          node-version: 20
+      - name: Lint
+        run: pnpm lint
 
   floating:
     name: "Floating Dependencies"
     runs-on: ubuntu-latest
+    needs: [test]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: wyvox/action-setup-pnpm@v3
         with:
-          node-version: 16
-      - name: Run Tests
-        run: pnpm test
+          args: '--no-lockfile'
+          node-version: 20          
+      - run: pnpm test
 
   try-scenarios:
     name: ${{ matrix.try-scenario }}
     runs-on: ubuntu-latest
-    needs: 'test'
+    needs: [test]
 
     strategy:
       fail-fast: false
@@ -56,10 +79,10 @@ jobs:
           - embroider-optimized
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: wyvox/action-setup-pnpm@v3
         with:
-          node-version: 16
+          node-version: 20
       - name: Run Tests
         run: ./node_modules/.bin/ember try:one ${{ matrix.try-scenario }} --skip-cleanup
         working-directory: test-app


### PR DESCRIPTION
- make sure install succeeds before running any other job
- split lint from tests so we can get right to seeing if tests fail
  - lints are less important "while working on something"
- specify to node 20, as 16 is ded
- actually use `--no-lockfile` for the floating-dependencies test
- upgrade actions/checkout