### PR TITLE
fix indentation in GitHub CI workflow

### DIFF
--- a/files/.github/workflows/ci.yml
+++ b/files/.github/workflows/ci.yml
@@ -8,8 +8,8 @@ on:
   pull_request: {}
 
 concurrency:
-   group: ci-${{ github.head_ref || github.ref }}
-   cancel-in-progress: true
+  group: ci-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:

--- a/tests/fixtures/default/.github/workflows/ci.yml
+++ b/tests/fixtures/default/.github/workflows/ci.yml
@@ -8,8 +8,8 @@ on:
   pull_request: {}
 
 concurrency:
-   group: ci-${{ github.head_ref || github.ref }}
-   cancel-in-progress: true
+  group: ci-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:

--- a/tests/fixtures/pnpm/.github/workflows/ci.yml
+++ b/tests/fixtures/pnpm/.github/workflows/ci.yml
@@ -8,8 +8,8 @@ on:
   pull_request: {}
 
 concurrency:
-   group: ci-${{ github.head_ref || github.ref }}
-   cancel-in-progress: true
+  group: ci-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:

--- a/tests/fixtures/yarn/.github/workflows/ci.yml
+++ b/tests/fixtures/yarn/.github/workflows/ci.yml
@@ -8,8 +8,8 @@ on:
   pull_request: {}
 
 concurrency:
-   group: ci-${{ github.head_ref || github.ref }}
-   cancel-in-progress: true
+  group: ci-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:


### PR DESCRIPTION
All generated files should match Prettier's conventions. We may want to add test coverage for that in a follow-up PR.