### PR TITLE
[TS] Add plugin to fix bad declaratioun output

### DIFF
--- a/files/__addonLocation__/package.json
+++ b/files/__addonLocation__/package.json
@@ -82,6 +82,8 @@
     "prettier-plugin-ember-template-tag": "^1.1.0",
     "rollup": "^4.9.1"<% if (!isExistingMonorepo) { %>,
     "rollup-plugin-copy": "^3.5.0"<% } %><% if (typescript) { %>,
+    "execa": '^8.0.1",
+    "fix-bad-declaration-output": "^1.1.2",
     "typescript": "^5.3.3"<% } %>
   },
   "publishConfig": {


### PR DESCRIPTION
When using `--typescript`,
- add a plugin that generates the types and fixes the output of those types, due to:
  - https://github.com/microsoft/TypeScript/issues/56571
  - https://github.com/typed-ember/glint/issues/628


Closes: https://github.com/embroider-build/addon-blueprint/issues/248