### PR TITLE
Add missing .gitignores to better support --addon-only scenarios (no test app)

### DIFF
--- a/files/__addonLocation__/gitignore
+++ b/files/__addonLocation__/gitignore
@@ -5,8 +5,13 @@
 /LICENSE.md
 
 # compiled output
-/dist
-/declarations
+dist/
+declarations/
 
 # npm/pnpm/yarn pack output
 *.tgz
+
+# deps & caches
+node_modules/
+.eslintcache
+.prettiercache

--- a/tests/smoke-tests/--typescript.test.ts
+++ b/tests/smoke-tests/--typescript.test.ts
@@ -85,8 +85,8 @@ for (let packageManager of SUPPORTED_PACKAGE_MANAGERS) {
           "index.js",
           "index.js.map",
           "services",
-          "template-only-dYTzhOEA.js",
-          "template-only-dYTzhOEA.js.map",
+          "template-only-B8yJqW69.js",
+          "template-only-B8yJqW69.js.map",
           "template-registry.js",
           "template-registry.js.map",
         ]


### PR DESCRIPTION
I've been using `--addon-only` a lot lately (no test-app, only generates the addon),
and noticed that some .gitignore entries were missing.

To protect silly files from accidentally getting committed to git, I've added more entries to the .gitignore.

My use case is _likely_ not my own, but also we want to actually support a non-monorepo layout eventually anyway, so this progresses us towards that as well.


~~atm, it looks like `main` is broken: https://github.com/embroider-build/addon-blueprint/actions/runs/7864883532
But: https://github.com/ember-cli/ember-cli/issues/10443
But also: https://github.com/platinumazure/eslint-plugin-qunit/issues/478~~