### PR TITLE
fix workspace definition

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,4 @@
 packages:
-  # any directory (including the top level)
-  - '*'
-  # ignore everything in the files directory
-  - '!files'
+  - '.'
+  - 'tests'
 


### PR DESCRIPTION
This is the reason why https://github.com/embroider-build/addon-blueprint/pull/261 is not picking up the minor change that I expected it to. I suspect that this stopped working because of https://github.com/embroider-build/addon-blueprint/pull/260 now using `manypkg` and getting confused by the `*` in the workspace definition

edit: I tested `release-plan` with this change locally and it does fix it 👍 