### PR TITLE
add a timeout minutes to the CI jobs

### DIFF
--- a/files/.github/workflows/ci.yml
+++ b/files/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
   test:
     name: "Tests"
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v4<% if (pnpm) { %>
@@ -35,6 +36,7 @@ jobs:
   floating:
     name: "Floating Dependencies"
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v4<% if (pnpm) { %>
@@ -54,6 +56,7 @@ jobs:
     name: ${{ matrix.try-scenario }}
     runs-on: ubuntu-latest
     needs: 'test'
+    timeout-minutes: 10
 
     strategy:
       fail-fast: false

--- a/files/.github/workflows/push-dist.yml
+++ b/files/.github/workflows/push-dist.yml
@@ -15,6 +15,8 @@ jobs:
   push-dist:
     name: Push dist
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+
     steps:
       - uses: actions/checkout@v4<% if (pnpm) { %>
       - uses: pnpm/action-setup@v3


### PR DESCRIPTION
This is just taking the implementation from https://github.com/ember-cli/ember-cli/pull/9760 which must have been added to ember-cli after we "forked" from there