### PR TITLE
Sort dependencies in root `package.json` file

### DIFF
--- a/files/package.json
+++ b/files/package.json
@@ -4,11 +4,11 @@
   "license": "MIT",
   "author": "",
   "scripts": {},
-  "devDependencies": {
+  "devDependencies": {<% if (typescript) { %>
+    "@glint/core": "^1.2.1",<% } %>
     "concurrently": "^8.2.0",
     "prettier": "^3.0.3",
-    "prettier-plugin-ember-template-tag": "^1.1.0"<% if (typescript) { %>,
-    "@glint/core": "^1.2.1"<% } %>    
+    "prettier-plugin-ember-template-tag": "^1.1.0"
   },
   "workspaces": [
     "<%= addonInfo.location %>",


### PR DESCRIPTION
This prevents unnecessary changes when installing packages, since package managers sort dependencies alphabetically.