### PR TITLE
 Because TS addons need to emit declarations, we need to set noEmit to false

### DIFF
--- a/files/__addonLocation__/tsconfig.json
+++ b/files/__addonLocation__/tsconfig.json
@@ -10,6 +10,25 @@
   "compilerOptions": {
     "allowJs": true,
     "declarationDir": "declarations",
+    /**
+      https://www.typescriptlang.org/tsconfig#noEmit
+
+      We want to emit declarations, so this option must be set to `false`.
+      @tsconfig/ember sets this to `true`, which is incompatible with our need to set `emitDeclarationOnly`.
+      @tsconfig/ember is more optimized for apps, which wouldn't emit anything, only type check.
+    */
+    "noEmit": false,
+    /**
+      https://www.typescriptlang.org/tsconfig#emitDeclarationOnly
+      We want to only emit declarations as we use Rollup to emit JavaScript.
+    */
+    "emitDeclarationOnly": true,
+
+    /**
+      https://www.typescriptlang.org/tsconfig#noEmitOnError
+      Do not block emit on TS errors.
+    */
+    "noEmitOnError": false,
 
     /**
       https://www.typescriptlang.org/tsconfig#rootDir


### PR DESCRIPTION
Originally opened in #271 

-----

if you add `emitDeclarationOnly: true`, you get silent fail, (exit 0), no declaration.

if you run `tsc --decalaration` to get debugging info on the config, you get this error:
```
❯ tsc --declaration
tsconfig.json:17:5 - error TS5053: Option 'emitDeclarationOnly' cannot be specified with option 'noEmit'.

17     "emitDeclarationOnly": true,
       ~~~~~~~~~~~~~~~~~~~~~


Found 1 error in tsconfig.json:17
```


We are a bit at-odds with `@tsconfig/ember`, because it's designed for apps, and libraries just inherently have different needs.


-------

To test locally: 
```
❯ npx ember-cli@5.7 addon --blueprint ../OpenSource/emberjs/addon-blueprint --pnpm --typescript test-declaration-checking-and-generation

```