### PR TITLE
Add ESLint rule to require that relative imports use full extensions

### DIFF
--- a/files/__addonLocation__/.eslintrc.cjs
+++ b/files/__addonLocation__/.eslintrc.cjs
@@ -10,7 +10,7 @@ module.exports = {
       root: __dirname,
     },<% } %>
   },
-  plugins: ['ember'],
+  plugins: ['ember', 'import'],
   extends: [
     'eslint:recommended',
     'plugin:ember/recommended',
@@ -30,6 +30,20 @@ module.exports = {
       ],
       rules: {
         // Add any custom rules here
+      },
+    },
+    // require relative imports use full extensions
+    {
+      files: ['src/**/*.{js,ts,gjs,gts}'],
+      rules: {
+        'import/extensions': ['error', 'always', { ignorePackages: true }],
+      },
+    },
+<% } else { %>    // require relative imports use full extensions
+    {
+      files: ['src/**/*.{js,gjs}'],
+      rules: {
+        'import/extensions': ['error', 'always', { ignorePackages: true }],
       },
     },
 <% } %>    // node files

--- a/files/__addonLocation__/package.json
+++ b/files/__addonLocation__/package.json
@@ -76,6 +76,7 @@
     "eslint": "^8.56.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-ember": "^11.12.0",
+    "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-n": "^16.4.0",
     "eslint-plugin-prettier": "^5.0.1",
     "prettier": "^3.1.1",

--- a/tests/fixtures/default/my-addon/src/components/template-import.gjs
+++ b/tests/fixtures/default/my-addon/src/components/template-import.gjs
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import TemplateOnly from './template-only';
+import TemplateOnly from './template-only.js';
 import { on } from '@ember/modifier';
 
 export default class TemplateImport extends Component {

--- a/tests/fixtures/default/my-addon/src/components/template-only.js
+++ b/tests/fixtures/default/my-addon/src/components/template-only.js
@@ -1,0 +1,3 @@
+import templateOnly from '@ember/component/template-only';
+
+export default templateOnly();

--- a/tests/fixtures/typescript/my-addon/src/components/template-import.gts
+++ b/tests/fixtures/typescript/my-addon/src/components/template-import.gts
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import TemplateOnly from './template-only';
+import TemplateOnly from './template-only.ts';
 import AnotherGts from './another-gts.gts'; // N.B. relative imports inside a v2 addon should have explicit file extensions (this is consistent with how node treats ES modules)
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';

--- a/tests/smoke-tests/--typescript.test.ts
+++ b/tests/smoke-tests/--typescript.test.ts
@@ -85,8 +85,6 @@ for (let packageManager of SUPPORTED_PACKAGE_MANAGERS) {
           "index.js",
           "index.js.map",
           "services",
-          "template-only-B8yJqW69.js",
-          "template-only-B8yJqW69.js.map",
           "template-registry.js",
           "template-registry.js.map",
         ]


### PR DESCRIPTION
Closes #220

Even though type-only imports are not supported (see https://github.com/import-js/eslint-plugin-import/issues/2530), this already improves dx.