### PR TITLE
Make sure to use the correct package manager in concurrently scripts

### DIFF
--- a/files/__addonLocation__/package.json
+++ b/files/__addonLocation__/package.json
@@ -14,18 +14,18 @@
     "dist"
   ],
   "scripts": {<% if (typescript) { %>
-    "build": "concurrently 'npm:build:*'",
+    "build": "concurrently '<%= packageManager %>:build:*'",
     "build:js": "rollup --config",
     "build:types": "glint --declaration",<% } else { %>
     "build": "rollup --config",<% } %>
-    "lint": "concurrently 'npm:lint:*(!fix)' --names 'lint:'",
-    "lint:fix": "concurrently 'npm:lint:*:fix' --names 'fix:'",
+    "lint": "concurrently '<%= packageManager %>:lint:*(!fix)' --names 'lint:'",
+    "lint:fix": "concurrently '<%= packageManager %>:lint:*:fix' --names 'fix:'",
     "lint:hbs": "ember-template-lint . --no-error-on-unmatched-pattern",
     "lint:js": "eslint . --cache",
     "lint:hbs:fix": "ember-template-lint . --fix --no-error-on-unmatched-pattern",
     "lint:js:fix": "eslint . --fix",<% if (typescript) { %>
     "lint:types": "glint",
-    "start": "concurrently 'npm:start:*'",
+    "start": "concurrently '<%= packageManager %>:start:*'",
     "start:js": "rollup --config --watch --no-watch.clearScreen",
     "start:types": "glint --declaration --watch",<% } else { %>
     "start": "rollup --config --watch",<% } %>

--- a/src/root-package-json.js
+++ b/src/root-package-json.js
@@ -73,7 +73,7 @@ let scripts = {
       lint: 'yarn workspaces run lint',
       'lint:fix': 'yarn workspaces run lint:fix',
       prepare: 'yarn build',
-      start: "concurrently 'npm:start:*' --restart-after 5000 --prefix-colors cyan,white,yellow",
+      start: "concurrently 'yarn:start:*' --restart-after 5000 --prefix-colors cyan,white,yellow",
       'start:addon': `yarn workspace ${addonName} run start`,
       'start:test-app': `yarn workspace ${testAppName} run start`,
       test: 'yarn workspaces run test',
@@ -110,7 +110,7 @@ let scripts = {
        *
        * Colors are customizable
        */
-      start: "concurrently 'npm:start:*' --restart-after 5000 --prefix-colors cyan,white,yellow",
+      start: "concurrently 'pnpm:start:*' --restart-after 5000 --prefix-colors cyan,white,yellow",
       'start:addon': `pnpm --filter ${addonName} start --no-watch.clearScreen`,
       'start:test-app': `pnpm --filter ${testAppName} start`,
       /**


### PR DESCRIPTION
Use of `npm` was still hardcoded.

https://github.com/open-cli-tools/concurrently?tab=readme-ov-file#faq

> Does this work with the npm-replacements [yarn](https://github.com/yarnpkg/yarn), [pnpm](https://pnpm.js.org/), or [Bun](https://bun.sh/)?
>
> Yes! In all examples above, you may replace "npm" with "yarn", "pnpm", or "bun".