### PR TITLE
Upgrade the build dependencies in the addon's package.json

### DIFF
--- a/files/__addonLocation__/package.json
+++ b/files/__addonLocation__/package.json
@@ -34,18 +34,18 @@
   },
   "dependencies": {
     "@embroider/addon-shim": "^1.8.7",
-    "decorator-transforms": "^1.0.1"
+    "decorator-transforms": "^1.2.1"
   },
   "devDependencies": {
-    "@babel/core": "^7.23.6",
-    <% if (typescript) { %>"@babel/plugin-transform-typescript": "^7.23.6"<% } else { %>"@babel/eslint-parser": "^7.23.3"<% } %>,
-    "@babel/runtime": "^7.17.0",
-    "@embroider/addon-dev": "^4.1.0",<% if (typescript) { %>
-    "@glint/core": "^1.2.1",
-    "@glint/environment-ember-loose": "^1.2.1",
-    "@glint/environment-ember-template-imports": "^1.2.1",
-    "@glint/template": "^1.2.1",
-    "@tsconfig/ember": "^3.0.2",
+    "@babel/core": "^7.24.4",
+    <% if (typescript) { %>"@babel/plugin-transform-typescript": "^7.24.4"<% } else { %>"@babel/eslint-parser": "^7.24.4"<% } %>,
+    "@babel/runtime": "^7.24.4",
+    "@embroider/addon-dev": "^4.3.1",<% if (typescript) { %>
+    "@glint/core": "^1.4.0",
+    "@glint/environment-ember-loose": "^1.4.0",
+    "@glint/environment-ember-template-imports": "^1.4.0",
+    "@glint/template": "^1.4.0",
+    "@tsconfig/ember": "^3.0.6",
     "@types/ember": "^4.0.10",
     "@types/ember__object": "^4.0.11",
     "@types/ember__destroyable": "^4.0.4",
@@ -70,7 +70,7 @@
     "@typescript-eslint/eslint-plugin": "^6.14.0",
     "@typescript-eslint/parser": "^6.14.0",<% } %>
     "@rollup/plugin-babel": "^6.0.4",
-    "babel-plugin-ember-template-compilation": "^2.2.1",
+    "babel-plugin-ember-template-compilation": "^2.2.2",
     "concurrently": "^8.2.2",
     "ember-template-lint": "^5.13.0",
     "eslint": "^8.56.0",
@@ -81,9 +81,9 @@
     "eslint-plugin-prettier": "^5.0.1",
     "prettier": "^3.1.1",
     "prettier-plugin-ember-template-tag": "^1.1.0",
-    "rollup": "^4.9.1"<% if (!isExistingMonorepo) { %>,
+    "rollup": "^4.16.4"<% if (!isExistingMonorepo) { %>,
     "rollup-plugin-copy": "^3.5.0"<% } %><% if (typescript) { %>,
-    "typescript": "^5.3.3"<% } %>
+    "typescript": "^5.4.5"<% } %>
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"

--- a/files/__addonLocation__/package.json
+++ b/files/__addonLocation__/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.24.4",
-    <% if (typescript) { %>"@babel/plugin-transform-typescript": "^7.24.4"<% } else { %>"@babel/eslint-parser": "^7.24.4"<% } %>,
+    <% if (typescript) { %>"@babel/plugin-transform-typescript": "^7.24.4"<% } else { %>"@babel/eslint-parser": "^7.24.1"<% } %>,
     "@babel/runtime": "^7.24.4",
     "@embroider/addon-dev": "^4.3.1",<% if (typescript) { %>
     "@glint/core": "^1.4.0",


### PR DESCRIPTION
This is particularly important, because the upgrade of babel-plugin-ember-template-compilation fixes a bug that folks can very easily accidentally rely on (local variables not shadowing keywords)