### PR TITLE
Remove default `ciProvider` in `appOptions`

### DIFF
--- a/index.js
+++ b/index.js
@@ -191,7 +191,6 @@ module.exports = {
     await Promise.all([
       this.updateTestAppPackageJson(path.join(testAppPath, 'package.json'), isPnpm(options)),
       this.overrideTestAppFiles(testAppPath, path.join(options.target, 'test-app-overrides')),
-      fs.unlink(path.join(testAppPath, '.travis.yml')),
     ]);
 
     if (options.typescript) {

--- a/index.js
+++ b/index.js
@@ -183,7 +183,6 @@ module.exports = {
       entity: { name: testAppInfo.name.raw },
       name: testAppInfo.name.raw,
       rawName: testAppInfo.name.raw,
-      ciProvider: 'travis', // we will delete this anyway below, as the CI config goes into the root folder
       welcome: false,
     };
 


### PR DESCRIPTION
fix #289

We should avoid to set `travis` as default value for `ciProvider`, because in this case the `test-app` has in `ember-cli-update.json` as option `--ci-provider=travis`.

Travis was deprecated in v5 see https://deprecations.emberjs.com/ember-cli/v5.x/#toc_travis-ci-support