### PR TITLE
Provide workarounds for both TS (bad peer-provided types handling) and Glint (mishandling of extensions) issues

### DIFF
--- a/files/__addonLocation__/package.json
+++ b/files/__addonLocation__/package.json
@@ -13,11 +13,8 @@
     "declarations",
     "dist"
   ],
-  "scripts": {<% if (typescript) { %>
-    "build": "concurrently '<%= packageManager %>:build:*'",
-    "build:js": "rollup --config",
-    "build:types": "glint --declaration",<% } else { %>
-    "build": "rollup --config",<% } %>
+  "scripts": {
+    "build": "rollup --config",
     "lint": "concurrently '<%= packageManager %>:lint:*(!fix)' --names 'lint:'",
     "lint:fix": "concurrently '<%= packageManager %>:lint:*:fix' --names 'fix:'",
     "lint:hbs": "ember-template-lint . --no-error-on-unmatched-pattern",
@@ -84,6 +81,8 @@
     "prettier-plugin-ember-template-tag": "^2.0.2",
     "rollup": "^4.16.4"<% if (!isExistingMonorepo) { %>,
     "rollup-plugin-copy": "^3.5.0"<% } %><% if (typescript) { %>,
+    "execa": "9.2.0",
+    "fix-bad-declaration-output": "1.1.4",
     "typescript": "^5.4.5"<% } %>
   },
   "publishConfig": {

--- a/files/__addonLocation__/rollup.config.mjs
+++ b/files/__addonLocation__/rollup.config.mjs
@@ -82,7 +82,9 @@ export default {
          * but our consumers may not be using those, or have a new enough ember-source that provides them.
          */
         console.log("Building types");
-        await $({ stdio: 'inherit' })`./node_modules/.bin/glint --declaration`;
+        let command = npm ? 'npm exec glint -- --declaration' : `${packageManager} glint --declaration`;
+
+        await $({ stdio: 'inherit' })`${command}`;
 
         /**
          * https://github.com/microsoft/TypeScript/issues/56571#

--- a/files/__addonLocation__/rollup.config.mjs
+++ b/files/__addonLocation__/rollup.config.mjs
@@ -82,9 +82,11 @@ export default {
          * but our consumers may not be using those, or have a new enough ember-source that provides them.
          */
         console.log("Building types");
-        let command = npm ? 'npm exec glint -- --declaration' : `${packageManager} glint --declaration`;
-
-        await $({ stdio: 'inherit' })`${command}`;
+        <% if (npm) { %>
+        await $({ stdio: 'inherit' })`npm exec glint -- --declaration`;
+        <% } else { %>
+        await $({ stdio: 'inherit' })`<%= packageManager %> glint --declaration`;
+        <% } %>
 
         /**
          * https://github.com/microsoft/TypeScript/issues/56571#


### PR DESCRIPTION
This isn't ideal, and I would have PR'd it sooner, but I was kind of hoping that we'd have solutions to these problems by now... but we don't.

To unblock people and to make the blueprint _usable_ for folks wishing to use typescript, we need this work around.


Here are the issues that this PR resolves:
- https://github.com/microsoft/TypeScript/issues/56571#issuecomment-1830436576
- https://github.com/typed-ember/glint/issues/628
- https://github.com/typed-ember/glint/issues/697