### PR TITLE
Bump decorator-transforms to v2

### DIFF
--- a/files/__addonLocation__/package.json
+++ b/files/__addonLocation__/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@embroider/addon-shim": "^1.8.7",
-    "decorator-transforms": "^1.2.1"
+    "decorator-transforms": "^2.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.24.4",


### PR DESCRIPTION
v2 was release 2 months ago, so makes sense new for new addons to use latest version