### PR TITLE
Match prettier-plugin-ember-template-tag with version in addon/package.json

### DIFF
--- a/files/package.json
+++ b/files/package.json
@@ -8,7 +8,7 @@
     "@glint/core": "^1.2.1",<% } %>
     "concurrently": "^8.2.0",
     "prettier": "^3.0.3",
-    "prettier-plugin-ember-template-tag": "^1.1.0"
+    "prettier-plugin-ember-template-tag": "^2.0.2"
   },
   "workspaces": [
     "<%= addonInfo.location %>",


### PR DESCRIPTION
See issue #294 

Related to commit https://github.com/embroider-build/addon-blueprint/commit/8d2641dc5908774fd734d57ec8c11962aaba47f5