### PR TITLE
remove publishConfig from addon package.json

### DIFF
--- a/files/__addonLocation__/package.json
+++ b/files/__addonLocation__/package.json
@@ -86,9 +86,6 @@
     "rollup-plugin-copy": "^3.5.0"<% } %><% if (typescript) { %>,
     "typescript": "^5.4.5"<% } %>
   },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org"
-  },
   "ember": {
     "edition": "octane"
   },


### PR DESCRIPTION
This makes an assumption that the addon will be published to public NPM, which is not always the case (and sometimes, rarely the case, such as a company that uses an internal registry for private packages). IMHO it would be better to not make this assumption.

For context: I created a new private v2 addon for work and it took me a bit to realize why it kept attempting to publish to public NPM when we have release automation that publishes to our internal repo.