### PR TITLE
Escape script quotes

### DIFF
--- a/files/__addonLocation__/package.json
+++ b/files/__addonLocation__/package.json
@@ -14,23 +14,23 @@
     "dist"
   ],
   "scripts": {<% if (typescript) { %>
-    "build": "concurrently '<%= packageManager %>:build:*'",
+    "build": "concurrently \"<%= packageManager %>:build:*\"",
     "build:js": "rollup --config",
     "build:types": "glint --declaration",<% } else { %>
     "build": "rollup --config",<% } %>
-    "lint": "concurrently '<%= packageManager %>:lint:*(!fix)' --names 'lint:'",
-    "lint:fix": "concurrently '<%= packageManager %>:lint:*:fix' --names 'fix:'",
+    "lint": "concurrently \"<%= packageManager %>:lint:*(!fix)\" --names \"lint:\"",
+    "lint:fix": "concurrently \"<%= packageManager %>:lint:*:fix\" --names \"fix:\"",
     "lint:hbs": "ember-template-lint . --no-error-on-unmatched-pattern",
     "lint:js": "eslint . --cache",
     "lint:hbs:fix": "ember-template-lint . --fix --no-error-on-unmatched-pattern",
     "lint:js:fix": "eslint . --fix",<% if (typescript) { %>
     "lint:types": "glint",
-    "start": "concurrently '<%= packageManager %>:start:*'",
+    "start": "concurrently \"<%= packageManager %>:start:*\"",
     "start:js": "rollup --config --watch --no-watch.clearScreen",
     "start:types": "glint --declaration --watch",<% } else { %>
     "start": "rollup --config --watch",<% } %>
-    "test": "echo 'A v2 addon does not have tests, run tests in test-app'",
-    "prepack": <% if (typescript) { %>"concurrently '<%= packageManager %>:build:*'"<% } else { %>"rollup --config"<% } %>
+    "test": "echo \"A v2 addon does not have tests, run tests in test-app\"",
+    "prepack": <% if (typescript) { %>"concurrently \"<%= packageManager %>:build:*\""<% } else { %>"rollup --config"<% } %>
   },
   "dependencies": {
     "@embroider/addon-shim": "^1.8.7",

--- a/src/root-package-json.js
+++ b/src/root-package-json.js
@@ -50,7 +50,7 @@ let scripts = {
       lint: 'npm run lint --workspaces --if-present',
       'lint:fix': 'npm run lint:fix --workspaces --if-present',
       prepare: 'npm run build',
-      start: "concurrently 'npm:start:*' --restart-after 5000 --prefix-colors cyan,white,yellow",
+      start: "concurrently \"npm:start:*\" --restart-after 5000 --prefix-colors cyan,white,yellow",
       'start:addon': `npm start --workspace ${addonName} -- --no-watch.clearScreen`,
       'start:test-app': `npm start --workspace ${testAppName}`,
       test: 'npm run test --workspaces --if-present',
@@ -73,7 +73,7 @@ let scripts = {
       lint: 'yarn workspaces run lint',
       'lint:fix': 'yarn workspaces run lint:fix',
       prepare: 'yarn build',
-      start: "concurrently 'yarn:start:*' --restart-after 5000 --prefix-colors cyan,white,yellow",
+      start: "concurrently \"yarn:start:*\" --restart-after 5000 --prefix-colors cyan,white,yellow",
       'start:addon': `yarn workspace ${addonName} run start`,
       'start:test-app': `yarn workspace ${testAppName} run start`,
       test: 'yarn workspaces run test',
@@ -94,8 +94,8 @@ let scripts = {
 
     return {
       build: `pnpm --filter ${addonName} build`,
-      lint: "pnpm --filter '*' lint",
-      'lint:fix': "pnpm --filter '*' lint:fix",
+      lint: "pnpm --filter \"*\" lint",
+      'lint:fix': "pnpm --filter \"*\" lint:fix",
       /**
        * For most optimized C.I., this will likely want to be removed, but
        * the prepare scripts helps folks get going quicker without having to understand
@@ -110,7 +110,7 @@ let scripts = {
        *
        * Colors are customizable
        */
-      start: "concurrently 'pnpm:start:*' --restart-after 5000 --prefix-colors cyan,white,yellow",
+      start: "concurrently \"pnpm:start:*\" --restart-after 5000 --prefix-colors cyan,white,yellow",
       'start:addon': `pnpm --filter ${addonName} start --no-watch.clearScreen`,
       'start:test-app': `pnpm --filter ${testAppName} start`,
       /**
@@ -119,8 +119,8 @@ let scripts = {
        * package.json script -- but will be present in C.I.
        *  (this is a consequence of enforced strict peers)
        */
-      test: "pnpm --filter '*' test",
-      'test:ember': "pnpm --filter '*' test:ember",
+      test: "pnpm --filter \"*\" test",
+      'test:ember': "pnpm --filter \"*\" test:ember",
     };
   },
 };


### PR DESCRIPTION
Swaps out single-quotes for escaped double-quotes in the generated package.json files at the root and in the addon folder. This will allow addon authors using Windows to run the scripts.

Closes #302 