### PR TITLE
ember-source is required for babel-plugin-ember-template-compilation

### DIFF
--- a/files/__addonLocation__/package.json
+++ b/files/__addonLocation__/package.json
@@ -37,7 +37,7 @@
     "decorator-transforms": "^2.0.0"
   },
   "peerDependencies": {
-    "ember-source": ">= <%= latestEmberSource %>"
+    "ember-source": ">= 5.4.0"
   },
   "devDependencies": {
     "@babel/core": "^7.24.4",
@@ -75,7 +75,7 @@
     "@rollup/plugin-babel": "^6.0.4",
     "babel-plugin-ember-template-compilation": "^2.2.5",
     "concurrently": "^8.2.2",
-    "ember-source": "^<%= latestEmberSource %>",
+    "ember-source": "^5.4.0",
     "ember-template-lint": "^6.0.0",<% if (packageManager === 'npm') { %>
     "ember-eslint-parser": "^0.4.2",
     <% } %>"eslint": "^8.56.0",

--- a/files/__addonLocation__/package.json
+++ b/files/__addonLocation__/package.json
@@ -36,6 +36,9 @@
     "@embroider/addon-shim": "^1.8.7",
     "decorator-transforms": "^2.0.0"
   },
+  "peerDependencies": {
+    "ember-source": ">= <%= latestEmberSource %>"
+  },
   "devDependencies": {
     "@babel/core": "^7.24.4",
     <% if (typescript) { %>"@babel/plugin-transform-typescript": "^7.24.4"<% } else { %>"@babel/eslint-parser": "^7.24.1"<% } %>,
@@ -72,6 +75,7 @@
     "@rollup/plugin-babel": "^6.0.4",
     "babel-plugin-ember-template-compilation": "^2.2.5",
     "concurrently": "^8.2.2",
+    "ember-source": "^<%= latestEmberSource %>",
     "ember-template-lint": "^6.0.0",<% if (packageManager === 'npm') { %>
     "ember-eslint-parser": "^0.4.2",
     <% } %>"eslint": "^8.56.0",

--- a/files/__addonLocation__/package.json
+++ b/files/__addonLocation__/package.json
@@ -37,7 +37,7 @@
     "decorator-transforms": "^2.0.0"
   },
   "peerDependencies": {
-    "ember-source": ">= 5.4.0"
+    "ember-source": ">= 4.12.0"
   },
   "devDependencies": {
     "@babel/core": "^7.24.4",

--- a/index.js
+++ b/index.js
@@ -286,6 +286,7 @@ module.exports = {
       pnpm: isPnpm(options),
       npm: isNpm(options),
       typescript: options.typescript,
+      latestEmberSource: '5.12.0',
       ext: options.typescript ? 'ts' : 'js',
       blueprint: 'addon',
       blueprintOptions: buildBlueprintOptions({
@@ -309,7 +310,11 @@ module.exports = {
     let files = this._super.files.apply(this, arguments);
 
     if (options.addonOnly) {
-      files = files.filter((filename) => filename.includes('__addonLocation__') || filesToCopyFromRootToAddonInAddonOnlyMode.includes(filename));
+      files = files.filter(
+        (filename) =>
+          filename.includes('__addonLocation__') ||
+          filesToCopyFromRootToAddonInAddonOnlyMode.includes(filename),
+      );
     } else {
       // filter out the addon-specific npmrc, as it
       // is only applicable during --addon-only
@@ -386,4 +391,3 @@ function isYarn(options) {
 function isNpm(options) {
   return options.packageManager === 'npm' || options.npm;
 }
-

--- a/index.js
+++ b/index.js
@@ -286,7 +286,6 @@ module.exports = {
       pnpm: isPnpm(options),
       npm: isNpm(options),
       typescript: options.typescript,
-      latestEmberSource: '5.12.0',
       ext: options.typescript ? 'ts' : 'js',
       blueprint: 'addon',
       blueprintOptions: buildBlueprintOptions({


### PR DESCRIPTION
CI is currently failing on main, as does `pnpm build` in a real generated project (which is what CI does).

