### PR TITLE
Require node 18+

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,11 +34,10 @@
     "typescript": "^4.7.4"
   },
   "engines": {
-    "node": "16.* || >= 18"
+    "node": "18.* || >= 20"
   },
   "volta": {
-    "node": "16.20.1",
-    "yarn": "1.22.18",
+    "node": "18.20.5",
     "pnpm": "8.7.6"
   },
   "publishConfig": {


### PR DESCRIPTION
Time to upgrade. Had trouble running pnpm with core-pack enabled on that old node version.

CI was already running on node 18...