### PR TITLE
Sync `concurrently` with cli / blueprint

### DIFF
--- a/files/package.json
+++ b/files/package.json
@@ -7,7 +7,7 @@
   "packageManager": "<%= pnpm ? 'pnpm@10.0.0' : 'npm@11.0.0' %>",
   "devDependencies": {<% if (typescript) { %>
     "@glint/core": "^1.2.1",<% } %>
-    "concurrently": "^8.2.0",
+    "concurrently": "^9.1.2",
     "prettier": "^3.0.3",
     "prettier-plugin-ember-template-tag": "^2.0.2"
   },


### PR DESCRIPTION
The `concurrently` in root `package.json` is still v8.
ember-cli & also addon blueprint are on v9