### PR TITLE
Remove pnpm version from pnpm/action-setup

### DIFF
--- a/files/.github/workflows/ci.yml
+++ b/files/.github/workflows/ci.yml
@@ -19,9 +19,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4<% if (pnpm) { %>
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 8<% } %>
+      - uses: pnpm/action-setup@v4<% } %>
       - uses: actions/setup-node@v4
         with:
           node-version: 18

--- a/tests/fixtures/pnpm/.github/workflows/ci.yml
+++ b/tests/fixtures/pnpm/.github/workflows/ci.yml
@@ -20,8 +20,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-        with:
-          version: 8
       - uses: actions/setup-node@v4
         with:
           node-version: 18


### PR DESCRIPTION
I generated a fresh --pnpm version of the blueprint and ran into an issue with CI not liking that a version for `pnpm` was still specified while we also have `packageManager` set preventing CI from running at all.

They were out of sync as well (v8 in CI, v10 in package.json), but apparently it's no longer needed to specify a version in the CI config if `packageManager` is set in package.json.

Example CI error: https://github.com/nickschot/macros-reproduction/actions/runs/13472870355
Docs for the action: https://github.com/pnpm/action-setup?tab=readme-ov-file#version