### PR TITLE
Remove remaining pnpm version from pnpm/action-setup

### DIFF
--- a/files/.github/workflows/ci.yml
+++ b/files/.github/workflows/ci.yml
@@ -38,9 +38,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4<% if (pnpm) { %>
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 8<% } %>
+      - uses: pnpm/action-setup@v4<% } %>
       - uses: actions/setup-node@v4
         with:
           node-version: 18
@@ -70,9 +68,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4<% if (pnpm) { %>
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 8<% } %>
+      - uses: pnpm/action-setup@v4<% } %>
       - uses: actions/setup-node@v4
         with:
           node-version: 18

--- a/files/.github/workflows/push-dist.yml
+++ b/files/.github/workflows/push-dist.yml
@@ -19,9 +19,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4<% if (pnpm) { %>
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 8<% } %>
+      - uses: pnpm/action-setup@v4<% } %>
       - uses: actions/setup-node@v4
         with:
           node-version: 18

--- a/tests/fixtures/pnpm/.github/workflows/ci.yml
+++ b/tests/fixtures/pnpm/.github/workflows/ci.yml
@@ -39,8 +39,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-        with:
-          version: 8
       - uses: actions/setup-node@v4
         with:
           node-version: 18
@@ -71,8 +69,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-        with:
-          version: 8
       - uses: actions/setup-node@v4
         with:
           node-version: 18

--- a/tests/fixtures/pnpm/.github/workflows/push-dist.yml
+++ b/tests/fixtures/pnpm/.github/workflows/push-dist.yml
@@ -20,8 +20,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-        with:
-          version: 8
       - uses: actions/setup-node@v4
         with:
           node-version: 18


### PR DESCRIPTION
I don't know why, but in my [previous PR](https://github.com/embroider-build/addon-blueprint/pull/328) I missed a couple of these... so this removes the rest of them.

