### PR TITLE
Add permissions to the push-dist workflow

### DIFF
--- a/files/.github/workflows/push-dist.yml
+++ b/files/.github/workflows/push-dist.yml
@@ -14,6 +14,8 @@ on:
 jobs:
   push-dist:
     name: Push dist
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/tests/fixtures/default/.github/workflows/push-dist.yml
+++ b/tests/fixtures/default/.github/workflows/push-dist.yml
@@ -14,6 +14,8 @@ on:
 jobs:
   push-dist:
     name: Push dist
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/tests/fixtures/pnpm/.github/workflows/push-dist.yml
+++ b/tests/fixtures/pnpm/.github/workflows/push-dist.yml
@@ -14,6 +14,8 @@ on:
 jobs:
   push-dist:
     name: Push dist
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/tests/fixtures/yarn/.github/workflows/push-dist.yml
+++ b/tests/fixtures/yarn/.github/workflows/push-dist.yml
@@ -14,6 +14,8 @@ on:
 jobs:
   push-dist:
     name: Push dist
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     timeout-minutes: 10
 


### PR DESCRIPTION
Default new github repos don't have write contents permissions on github tokens