### PR TITLE
Remove ember-source as a peerDependency

### DIFF
--- a/files/__addonLocation__/package.json
+++ b/files/__addonLocation__/package.json
@@ -32,9 +32,6 @@
     "@embroider/addon-shim": "^1.8.9",
     "decorator-transforms": "^2.2.2"
   },
-  "peerDependencies": {
-    "ember-source": ">= 4.12.0"
-  },
   "devDependencies": {
     "@babel/core": "^7.25.2",
     <% if (typescript) { %>"@babel/plugin-transform-typescript": "^7.25.2",<% } %>

--- a/tests/smoke-tests/--typescript.test.ts
+++ b/tests/smoke-tests/--typescript.test.ts
@@ -94,10 +94,8 @@ for (let packageManager of SUPPORTED_PACKAGE_MANAGERS) {
         [
           "components",
           "index.d.ts",
-          "index.d.ts.map",
           "services",
           "template-registry.d.ts",
-          "template-registry.d.ts.map",
         ]
       `);
 

--- a/tests/smoke-tests/--typescript.test.ts
+++ b/tests/smoke-tests/--typescript.test.ts
@@ -94,8 +94,10 @@ for (let packageManager of SUPPORTED_PACKAGE_MANAGERS) {
         [
           "components",
           "index.d.ts",
+          "index.d.ts.map",
           "services",
           "template-registry.d.ts",
+          "template-registry.d.ts.map",
         ]
       `);
 


### PR DESCRIPTION
the embroider/auto-import infra make it so we don't need to declare this -- and peer problems will be easier if no one declares it.

I feel like it _used to be needed_, but whatever situation that was may have been a bug (or a misunderstanding of how to make dependencySatisfies work)